### PR TITLE
feat(auth): add authentication screens and services

### DIFF
--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:visiobook_mobile/core/utils/secure_storage.dart';
+import 'package:visiobook_mobile/features/auth/presentation/screens/splash_screen.dart';
+import 'package:visiobook_mobile/features/auth/presentation/screens/login_screen.dart';
+import 'package:visiobook_mobile/features/auth/presentation/screens/register_screen.dart';
 
 /// Routes de l'application
 class AppRoutes {
@@ -25,16 +28,15 @@ class AppRouter {
     routes: [
       GoRoute(
         path: AppRoutes.splash,
-        builder: (context, state) => const _PlaceholderScreen(title: 'Splash'),
+        builder: (context, state) => const SplashScreen(),
       ),
       GoRoute(
         path: AppRoutes.login,
-        builder: (context, state) => const _PlaceholderScreen(title: 'Login'),
+        builder: (context, state) => const LoginScreen(),
       ),
       GoRoute(
         path: AppRoutes.register,
-        builder: (context, state) =>
-            const _PlaceholderScreen(title: 'Register'),
+        builder: (context, state) => const RegisterScreen(),
       ),
       GoRoute(
         path: AppRoutes.dashboard,

--- a/lib/features/auth/data/auth_service.dart
+++ b/lib/features/auth/data/auth_service.dart
@@ -1,0 +1,151 @@
+import 'package:dio/dio.dart';
+import 'package:visiobook_mobile/core/network/api_client.dart';
+import 'package:visiobook_mobile/core/utils/secure_storage.dart';
+
+/// Resultat d'authentification
+class AuthResult {
+  final bool success;
+  final String? error;
+  final String? userId;
+
+  AuthResult({required this.success, this.error, this.userId});
+}
+
+/// Service d'authentification
+class AuthService {
+  final ApiClient _apiClient;
+  final SecureStorageService _storage;
+
+  AuthService({
+    required ApiClient apiClient,
+    required SecureStorageService storage,
+  }) : _apiClient = apiClient,
+       _storage = storage;
+
+  /// Connexion avec email et mot de passe
+  Future<AuthResult> login({
+    required String email,
+    required String password,
+  }) async {
+    try {
+      final response = await _apiClient.authLogin({
+        'email': email,
+        'password': password,
+      });
+
+      final data = response.data;
+      final accessToken = data['accessToken'] as String?;
+      final refreshToken = data['refreshToken'] as String?;
+      final userId = data['userId'] as String?;
+
+      if (accessToken != null && refreshToken != null) {
+        await _storage.saveAccessToken(accessToken);
+        await _storage.saveRefreshToken(refreshToken);
+        if (userId != null) {
+          await _storage.saveUserId(userId);
+        }
+        return AuthResult(success: true, userId: userId);
+      }
+
+      return AuthResult(success: false, error: 'Reponse invalide du serveur');
+    } on DioException catch (e) {
+      return _handleDioError(e);
+    } catch (e) {
+      return AuthResult(success: false, error: 'Erreur inattendue: $e');
+    }
+  }
+
+  /// Inscription
+  Future<AuthResult> register({
+    required String firstName,
+    required String email,
+    required String password,
+  }) async {
+    try {
+      final response = await _apiClient.authRegister({
+        'firstName': firstName,
+        'email': email,
+        'password': password,
+      });
+
+      final data = response.data;
+      final accessToken = data['accessToken'] as String?;
+      final refreshToken = data['refreshToken'] as String?;
+      final userId = data['userId'] as String?;
+
+      if (accessToken != null && refreshToken != null) {
+        await _storage.saveAccessToken(accessToken);
+        await _storage.saveRefreshToken(refreshToken);
+        if (userId != null) {
+          await _storage.saveUserId(userId);
+        }
+        return AuthResult(success: true, userId: userId);
+      }
+
+      return AuthResult(success: false, error: 'Reponse invalide du serveur');
+    } on DioException catch (e) {
+      return _handleDioError(e);
+    } catch (e) {
+      return AuthResult(success: false, error: 'Erreur inattendue: $e');
+    }
+  }
+
+  /// Deconnexion
+  Future<void> logout() async {
+    await _storage.clearTokens();
+  }
+
+  /// Verifie si l'utilisateur est connecte
+  Future<bool> isLoggedIn() async {
+    return _storage.isLoggedIn();
+  }
+
+  /// Gestion des erreurs Dio
+  AuthResult _handleDioError(DioException e) {
+    if (e.response != null) {
+      final statusCode = e.response!.statusCode;
+      final data = e.response!.data;
+
+      String message = 'Erreur serveur';
+      if (data is Map && data['message'] != null) {
+        message = data['message'];
+      }
+
+      switch (statusCode) {
+        case 400:
+          return AuthResult(success: false, error: message);
+        case 401:
+          return AuthResult(
+            success: false,
+            error: 'Email ou mot de passe incorrect',
+          );
+        case 409:
+          return AuthResult(
+            success: false,
+            error: 'Cet email est deja utilise',
+          );
+        case 422:
+          return AuthResult(success: false, error: 'Donnees invalides');
+        default:
+          return AuthResult(
+            success: false,
+            error: 'Erreur serveur ($statusCode)',
+          );
+      }
+    }
+
+    if (e.type == DioExceptionType.connectionTimeout ||
+        e.type == DioExceptionType.receiveTimeout) {
+      return AuthResult(
+        success: false,
+        error: 'Connexion au serveur impossible',
+      );
+    }
+
+    if (e.type == DioExceptionType.connectionError) {
+      return AuthResult(success: false, error: 'Pas de connexion internet');
+    }
+
+    return AuthResult(success: false, error: 'Erreur reseau');
+  }
+}

--- a/lib/features/auth/presentation/providers/auth_provider.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/foundation.dart';
+import 'package:visiobook_mobile/features/auth/data/auth_service.dart';
+
+/// Etats possibles de l'authentification
+enum AuthState { initial, loading, authenticated, unauthenticated, error }
+
+/// Provider pour gerer l'etat d'authentification
+class AuthProvider extends ChangeNotifier {
+  final AuthService _authService;
+
+  AuthState _state = AuthState.initial;
+  String? _error;
+
+  AuthProvider({required AuthService authService}) : _authService = authService;
+
+  AuthState get state => _state;
+  String? get error => _error;
+  bool get isLoading => _state == AuthState.loading;
+  bool get isAuthenticated => _state == AuthState.authenticated;
+
+  /// Verifie l'etat de connexion au demarrage
+  Future<void> checkAuthStatus() async {
+    _state = AuthState.loading;
+    notifyListeners();
+
+    final isLoggedIn = await _authService.isLoggedIn();
+
+    _state = isLoggedIn ? AuthState.authenticated : AuthState.unauthenticated;
+    notifyListeners();
+  }
+
+  /// Connexion
+  Future<bool> login({required String email, required String password}) async {
+    _state = AuthState.loading;
+    _error = null;
+    notifyListeners();
+
+    final result = await _authService.login(email: email, password: password);
+
+    if (result.success) {
+      _state = AuthState.authenticated;
+      notifyListeners();
+      return true;
+    } else {
+      _state = AuthState.error;
+      _error = result.error;
+      notifyListeners();
+      return false;
+    }
+  }
+
+  /// Inscription
+  Future<bool> register({
+    required String firstName,
+    required String email,
+    required String password,
+  }) async {
+    _state = AuthState.loading;
+    _error = null;
+    notifyListeners();
+
+    final result = await _authService.register(
+      firstName: firstName,
+      email: email,
+      password: password,
+    );
+
+    if (result.success) {
+      _state = AuthState.authenticated;
+      notifyListeners();
+      return true;
+    } else {
+      _state = AuthState.error;
+      _error = result.error;
+      notifyListeners();
+      return false;
+    }
+  }
+
+  /// Deconnexion
+  Future<void> logout() async {
+    await _authService.logout();
+    _state = AuthState.unauthenticated;
+    _error = null;
+    notifyListeners();
+  }
+
+  /// Reset l'erreur
+  void clearError() {
+    _error = null;
+    if (_state == AuthState.error) {
+      _state = AuthState.unauthenticated;
+    }
+    notifyListeners();
+  }
+}

--- a/lib/features/auth/presentation/screens/login_screen.dart
+++ b/lib/features/auth/presentation/screens/login_screen.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:lucide_icons/lucide_icons.dart';
+import 'package:provider/provider.dart';
+import 'package:visiobook_mobile/core/routing/app_router.dart';
+import 'package:visiobook_mobile/core/theme/app_theme.dart';
+import 'package:visiobook_mobile/core/utils/validators.dart';
+import 'package:visiobook_mobile/core/widgets/widgets.dart';
+import 'package:visiobook_mobile/features/auth/presentation/providers/auth_provider.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  bool _obscurePassword = true;
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _handleLogin() async {
+    if (!(_formKey.currentState?.validate() ?? false)) return;
+
+    final authProvider = context.read<AuthProvider>();
+
+    final success = await authProvider.login(
+      email: _emailController.text.trim(),
+      password: _passwordController.text,
+    );
+
+    if (success && mounted) {
+      context.go(AppRoutes.dashboard);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(LucideIcons.arrowLeft),
+          onPressed: () => context.pop(),
+        ),
+      ),
+      body: SafeArea(
+        child: Consumer<AuthProvider>(
+          builder: (context, authProvider, _) {
+            return SingleChildScrollView(
+              padding: const EdgeInsets.symmetric(horizontal: 32),
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  children: [
+                    const SizedBox(height: 48),
+                    Text(
+                      'Connexion',
+                      style: Theme.of(context).textTheme.displaySmall,
+                    ),
+                    const SizedBox(height: 48),
+                    if (authProvider.error != null) ...[
+                      Container(
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: AppColors.error.withValues(alpha: 0.1),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Row(
+                          children: [
+                            const Icon(
+                              LucideIcons.alertCircle,
+                              color: AppColors.error,
+                              size: 20,
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                authProvider.error!,
+                                style: const TextStyle(
+                                  color: AppColors.error,
+                                  fontSize: 14,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 24),
+                    ],
+                    AppInput(
+                      label: 'Email',
+                      placeholder: 'votre@email.com',
+                      controller: _emailController,
+                      keyboardType: TextInputType.emailAddress,
+                      validator: Validators.email,
+                      enabled: !authProvider.isLoading,
+                    ),
+                    const SizedBox(height: 20),
+                    AppInput(
+                      label: 'Mot de passe',
+                      placeholder: 'Votre mot de passe',
+                      controller: _passwordController,
+                      obscureText: _obscurePassword,
+                      validator: (value) =>
+                          Validators.required(value, 'Mot de passe'),
+                      enabled: !authProvider.isLoading,
+                      suffixIcon: IconButton(
+                        icon: Icon(
+                          _obscurePassword
+                              ? LucideIcons.eyeOff
+                              : LucideIcons.eye,
+                          color: AppColors.neutral500,
+                        ),
+                        onPressed: () {
+                          setState(() => _obscurePassword = !_obscurePassword);
+                        },
+                      ),
+                    ),
+                    const SizedBox(height: 32),
+                    AppButton(
+                      text: 'Se connecter',
+                      fullWidth: true,
+                      size: AppButtonSize.lg,
+                      isLoading: authProvider.isLoading,
+                      onPressed: authProvider.isLoading ? null : _handleLogin,
+                    ),
+                    const SizedBox(height: 24),
+                    TextButton(
+                      onPressed: authProvider.isLoading
+                          ? null
+                          : () {
+                              // TODO: Implement forgot password
+                            },
+                      child: Text(
+                        'Mot de passe oublie ?',
+                        style: TextStyle(
+                          color: AppColors.neutral500,
+                          fontSize: 14,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 48),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/screens/register_screen.dart
+++ b/lib/features/auth/presentation/screens/register_screen.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:lucide_icons/lucide_icons.dart';
+import 'package:provider/provider.dart';
+import 'package:visiobook_mobile/core/routing/app_router.dart';
+import 'package:visiobook_mobile/core/theme/app_theme.dart';
+import 'package:visiobook_mobile/core/utils/validators.dart';
+import 'package:visiobook_mobile/core/widgets/widgets.dart';
+import 'package:visiobook_mobile/features/auth/presentation/providers/auth_provider.dart';
+
+class RegisterScreen extends StatefulWidget {
+  const RegisterScreen({super.key});
+
+  @override
+  State<RegisterScreen> createState() => _RegisterScreenState();
+}
+
+class _RegisterScreenState extends State<RegisterScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _firstNameController = TextEditingController();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
+  bool _obscurePassword = true;
+  bool _obscureConfirmPassword = true;
+
+  @override
+  void dispose() {
+    _firstNameController.dispose();
+    _emailController.dispose();
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _handleRegister() async {
+    if (!(_formKey.currentState?.validate() ?? false)) return;
+
+    final authProvider = context.read<AuthProvider>();
+
+    final success = await authProvider.register(
+      firstName: _firstNameController.text.trim(),
+      email: _emailController.text.trim(),
+      password: _passwordController.text,
+    );
+
+    if (success && mounted) {
+      context.go(AppRoutes.dashboard);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(LucideIcons.arrowLeft),
+          onPressed: () => context.pop(),
+        ),
+      ),
+      body: SafeArea(
+        child: Consumer<AuthProvider>(
+          builder: (context, authProvider, _) {
+            return SingleChildScrollView(
+              padding: const EdgeInsets.symmetric(horizontal: 32),
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  children: [
+                    const SizedBox(height: 48),
+                    Text(
+                      'Creer un compte',
+                      style: Theme.of(context).textTheme.displaySmall,
+                    ),
+                    const SizedBox(height: 48),
+                    if (authProvider.error != null) ...[
+                      Container(
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: AppColors.error.withValues(alpha: 0.1),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Row(
+                          children: [
+                            const Icon(
+                              LucideIcons.alertCircle,
+                              color: AppColors.error,
+                              size: 20,
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                authProvider.error!,
+                                style: const TextStyle(
+                                  color: AppColors.error,
+                                  fontSize: 14,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 24),
+                    ],
+                    AppInput(
+                      label: 'Prenom',
+                      placeholder: 'Votre prenom',
+                      controller: _firstNameController,
+                      keyboardType: TextInputType.name,
+                      validator: Validators.firstName,
+                      enabled: !authProvider.isLoading,
+                    ),
+                    const SizedBox(height: 20),
+                    AppInput(
+                      label: 'Email',
+                      placeholder: 'votre@email.com',
+                      controller: _emailController,
+                      keyboardType: TextInputType.emailAddress,
+                      validator: Validators.email,
+                      enabled: !authProvider.isLoading,
+                    ),
+                    const SizedBox(height: 20),
+                    AppInput(
+                      label: 'Mot de passe',
+                      placeholder: 'Minimum 8 caracteres',
+                      controller: _passwordController,
+                      obscureText: _obscurePassword,
+                      validator: Validators.password,
+                      enabled: !authProvider.isLoading,
+                      suffixIcon: IconButton(
+                        icon: Icon(
+                          _obscurePassword
+                              ? LucideIcons.eyeOff
+                              : LucideIcons.eye,
+                          color: AppColors.neutral500,
+                        ),
+                        onPressed: () {
+                          setState(() => _obscurePassword = !_obscurePassword);
+                        },
+                      ),
+                    ),
+                    const SizedBox(height: 20),
+                    AppInput(
+                      label: 'Confirmer le mot de passe',
+                      placeholder: 'Retapez votre mot de passe',
+                      controller: _confirmPasswordController,
+                      obscureText: _obscureConfirmPassword,
+                      validator: (value) => Validators.confirmPassword(
+                        value,
+                        _passwordController.text,
+                      ),
+                      enabled: !authProvider.isLoading,
+                      suffixIcon: IconButton(
+                        icon: Icon(
+                          _obscureConfirmPassword
+                              ? LucideIcons.eyeOff
+                              : LucideIcons.eye,
+                          color: AppColors.neutral500,
+                        ),
+                        onPressed: () {
+                          setState(
+                            () => _obscureConfirmPassword =
+                                !_obscureConfirmPassword,
+                          );
+                        },
+                      ),
+                    ),
+                    const SizedBox(height: 32),
+                    AppButton(
+                      text: "S'enregistrer",
+                      fullWidth: true,
+                      size: AppButtonSize.lg,
+                      isLoading: authProvider.isLoading,
+                      onPressed: authProvider.isLoading
+                          ? null
+                          : _handleRegister,
+                    ),
+                    const SizedBox(height: 48),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/screens/splash_screen.dart
+++ b/lib/features/auth/presentation/screens/splash_screen.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:visiobook_mobile/core/widgets/app_button.dart';
+import 'package:visiobook_mobile/core/routing/app_router.dart';
+
+class SplashScreen extends StatelessWidget {
+  const SplashScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 32),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Spacer(),
+              Text(
+                'Prets a\ntransformer\nla lecture ?',
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.displayLarge,
+              ),
+              const Spacer(),
+              AppButton(
+                text: 'Se connecter',
+                fullWidth: true,
+                size: AppButtonSize.lg,
+                onPressed: () => context.push(AppRoutes.login),
+              ),
+              const SizedBox(height: 12),
+              AppButton(
+                text: "S'enregistrer",
+                variant: AppButtonVariant.outline,
+                fullWidth: true,
+                size: AppButtonSize.lg,
+                onPressed: () => context.push(AppRoutes.register),
+              ),
+              const SizedBox(height: 48),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:visiobook_mobile/core/theme/app_theme.dart';
+import 'package:provider/provider.dart';
+import 'package:visiobook_mobile/core/network/api_client.dart';
 import 'package:visiobook_mobile/core/routing/app_router.dart';
+import 'package:visiobook_mobile/core/theme/app_theme.dart';
 import 'package:visiobook_mobile/core/utils/secure_storage.dart';
+import 'package:visiobook_mobile/features/auth/data/auth_service.dart';
+import 'package:visiobook_mobile/features/auth/presentation/providers/auth_provider.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -23,16 +27,28 @@ class VisioBookApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Services
     final storage = SecureStorageService();
+    final apiClient = ApiClient(storage: storage);
+    final authService = AuthService(apiClient: apiClient, storage: storage);
+
+    // Router
     final appRouter = AppRouter(storage: storage);
 
-    return MaterialApp.router(
-      title: 'VisioBook',
-      debugShowCheckedModeBanner: false,
-      theme: AppTheme.lightTheme,
-      darkTheme: AppTheme.darkTheme,
-      themeMode: ThemeMode.light,
-      routerConfig: appRouter.router,
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(
+          create: (_) => AuthProvider(authService: authService),
+        ),
+      ],
+      child: MaterialApp.router(
+        title: 'VisioBook',
+        debugShowCheckedModeBanner: false,
+        theme: AppTheme.lightTheme,
+        darkTheme: AppTheme.darkTheme,
+        themeMode: ThemeMode.light,
+        routerConfig: appRouter.router,
+      ),
     );
   }
 }

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,0 +1,48 @@
+PODS:
+  - connectivity_plus (0.0.1):
+    - FlutterMacOS
+  - file_selector_macos (0.0.1):
+    - FlutterMacOS
+  - flutter_secure_storage_macos (6.1.3):
+    - FlutterMacOS
+  - FlutterMacOS (1.0.0)
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - video_player_avfoundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - connectivity_plus (from `Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos`)
+  - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
+  - flutter_secure_storage_macos (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos`)
+  - FlutterMacOS (from `Flutter/ephemeral`)
+  - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - video_player_avfoundation (from `Flutter/ephemeral/.symlinks/plugins/video_player_avfoundation/darwin`)
+
+EXTERNAL SOURCES:
+  connectivity_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos
+  file_selector_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos
+  flutter_secure_storage_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos
+  FlutterMacOS:
+    :path: Flutter/ephemeral
+  shared_preferences_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
+  video_player_avfoundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/video_player_avfoundation/darwin
+
+SPEC CHECKSUMS:
+  connectivity_plus: 4adf20a405e25b42b9c9f87feff8f4b6fde18a4e
+  file_selector_macos: 9e9e068e90ebee155097d00e89ae91edb2374db7
+  flutter_secure_storage_macos: 7f45e30f838cf2659862a4e4e3ee1c347c2b3b54
+  FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
+  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  video_player_avfoundation: dd410b52df6d2466a42d28550e33e4146928280a
+
+PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
+
+COCOAPODS: 1.16.2

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -21,12 +21,14 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		1D4F0F9221D6D3B5AAEF018F /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21F0ECF10A65E99E6AB2A584 /* Pods_Runner.framework */; };
 		331C80D8294CF71000263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C80D7294CF71000263BE5 /* RunnerTests.swift */; };
 		335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */; };
 		33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC10F02044A3C60003C045 /* AppDelegate.swift */; };
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		50B0C66E597850AF41D4494E /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B8E2AD0F88230B17FDAF3E7 /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,11 +62,15 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0B8E2AD0F88230B17FDAF3E7 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		117A9111465653EAF3D041E4 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		11F487722AE2E750B9C9CA23 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		21F0ECF10A65E99E6AB2A584 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D5294CF71000263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* visiobook_mobile.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "visiobook_mobile.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* visiobook_mobile.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = visiobook_mobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -78,6 +84,10 @@
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		A7B272F5AFA5E4176FACB8D9 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		AA284A9A4B3F8C28539B9F1F /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		DA8D3BC5C7DB9795DD92B498 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		E781E33D2ECCA39A7708F5A4 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +95,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				50B0C66E597850AF41D4494E /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -92,6 +103,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1D4F0F9221D6D3B5AAEF018F /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -125,6 +137,7 @@
 				331C80D6294CF71000263BE5 /* RunnerTests */,
 				33CC10EE2044A3C60003C045 /* Products */,
 				D73912EC22F37F3D000D13A0 /* Frameworks */,
+				F6CB1E27A949A896107BEFF1 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -175,8 +188,24 @@
 		D73912EC22F37F3D000D13A0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				21F0ECF10A65E99E6AB2A584 /* Pods_Runner.framework */,
+				0B8E2AD0F88230B17FDAF3E7 /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		F6CB1E27A949A896107BEFF1 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				117A9111465653EAF3D041E4 /* Pods-Runner.debug.xcconfig */,
+				DA8D3BC5C7DB9795DD92B498 /* Pods-Runner.release.xcconfig */,
+				A7B272F5AFA5E4176FACB8D9 /* Pods-Runner.profile.xcconfig */,
+				11F487722AE2E750B9C9CA23 /* Pods-RunnerTests.debug.xcconfig */,
+				E781E33D2ECCA39A7708F5A4 /* Pods-RunnerTests.release.xcconfig */,
+				AA284A9A4B3F8C28539B9F1F /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -186,6 +215,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C80DE294CF71000263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				99169AB73E82A56864EB8657 /* [CP] Check Pods Manifest.lock */,
 				331C80D1294CF70F00263BE5 /* Sources */,
 				331C80D2294CF70F00263BE5 /* Frameworks */,
 				331C80D3294CF70F00263BE5 /* Resources */,
@@ -204,11 +234,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				81D24920DC727C73606B3925 /* [CP] Check Pods Manifest.lock */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				BB39CCBEE2D6D54B4DBD30D7 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -329,6 +361,67 @@
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
 		};
+		81D24920DC727C73606B3925 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		99169AB73E82A56864EB8657 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		BB39CCBEE2D6D54B4DBD30D7 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -380,6 +473,7 @@
 /* Begin XCBuildConfiguration section */
 		331C80DB294CF71000263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 11F487722AE2E750B9C9CA23 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -394,6 +488,7 @@
 		};
 		331C80DC294CF71000263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E781E33D2ECCA39A7708F5A4 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -408,6 +503,7 @@
 		};
 		331C80DD294CF71000263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AA284A9A4B3F8C28539B9F1F /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;

--- a/macos/Runner.xcworkspace/contents.xcworkspacedata
+++ b/macos/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -464,6 +464,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  lucide_icons:
+    dependency: "direct main"
+    description:
+      name: lucide_icons
+      sha256: ad24d0fd65707e48add30bebada7d90bff2a1bba0a72d6e9b19d44246b0e83c4
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.257.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
 
   # UI
   cupertino_icons: ^1.0.8
+  lucide_icons: ^0.257.0
 
   # HTTP & Network
   dio: ^5.4.0


### PR DESCRIPTION
- Add lucide_icons dependency for UI icons
- Add AuthService with login/register/logout API calls
- Add AuthProvider for state management
- Add SplashScreen with login/register navigation
- Add LoginScreen with email/password validation
- Add RegisterScreen with form validation
- Update router to use real auth screens
- Update main.dart with Provider setup
- Handle API errors with user-friendly messages