### PR TITLE
feat: add mock data mode for UI testing without backend

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -23,6 +23,13 @@
 
 ---
 
+## Note importante
+
+> **MOCK DATA ACTIVE** : Pour tester l'UI sans backend, le mode mock est active dans `lib/config/environment.dart`.
+> Avant de connecter aux vrais microservices, mettre `useMockData = false`.
+
+---
+
 ## Priorites
 
 | Niveau | Signification | POK |

--- a/lib/config/environment.dart
+++ b/lib/config/environment.dart
@@ -4,6 +4,9 @@ enum Environment { dev, prod }
 class EnvironmentConfig {
   static Environment _current = Environment.dev;
 
+  /// Mode mock pour tester l'UI sans backend
+  static bool useMockData = true;
+
   static Environment get current => _current;
 
   static void setEnvironment(Environment env) {

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:visiobook_mobile/config/environment.dart';
 import 'package:visiobook_mobile/core/utils/secure_storage.dart';
 import 'package:visiobook_mobile/features/auth/presentation/screens/splash_screen.dart';
 import 'package:visiobook_mobile/features/auth/presentation/screens/login_screen.dart';
@@ -64,6 +65,11 @@ class AppRouter {
     BuildContext context,
     GoRouterState state,
   ) async {
+    // Mode mock: pas de redirection automatique, laisser le splash gerer
+    if (EnvironmentConfig.useMockData) {
+      return null;
+    }
+
     final isLoggedIn = await _storage.isLoggedIn();
     final isOnSplash = state.matchedLocation == AppRoutes.splash;
     final isOnAuth =

--- a/lib/features/auth/presentation/providers/auth_provider.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:visiobook_mobile/config/environment.dart';
 import 'package:visiobook_mobile/features/auth/data/auth_service.dart';
 
 /// Etats possibles de l'authentification
@@ -10,6 +11,7 @@ class AuthProvider extends ChangeNotifier {
 
   AuthState _state = AuthState.initial;
   String? _error;
+  String? _mockUserName;
 
   AuthProvider({required AuthService authService}) : _authService = authService;
 
@@ -17,9 +19,18 @@ class AuthProvider extends ChangeNotifier {
   String? get error => _error;
   bool get isLoading => _state == AuthState.loading;
   bool get isAuthenticated => _state == AuthState.authenticated;
+  String? get userName => _mockUserName;
 
   /// Verifie l'etat de connexion au demarrage
   Future<void> checkAuthStatus() async {
+    // Mode mock: auto-login
+    if (EnvironmentConfig.useMockData) {
+      _state = AuthState.authenticated;
+      _mockUserName = 'Marine';
+      notifyListeners();
+      return;
+    }
+
     _state = AuthState.loading;
     notifyListeners();
 

--- a/lib/features/auth/presentation/screens/splash_screen.dart
+++ b/lib/features/auth/presentation/screens/splash_screen.dart
@@ -1,10 +1,36 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
 import 'package:visiobook_mobile/core/widgets/app_button.dart';
 import 'package:visiobook_mobile/core/routing/app_router.dart';
+import 'package:visiobook_mobile/features/auth/presentation/providers/auth_provider.dart';
 
-class SplashScreen extends StatelessWidget {
+class SplashScreen extends StatefulWidget {
   const SplashScreen({super.key});
+
+  @override
+  State<SplashScreen> createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends State<SplashScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _checkAuthAndRedirect();
+    });
+  }
+
+  Future<void> _checkAuthAndRedirect() async {
+    final authProvider = context.read<AuthProvider>();
+    await authProvider.checkAuthStatus();
+
+    if (!mounted) return;
+
+    if (authProvider.isAuthenticated) {
+      context.go(AppRoutes.dashboard);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/projects/presentation/providers/project_provider.dart
+++ b/lib/features/projects/presentation/providers/project_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:visiobook_mobile/config/environment.dart';
 import 'package:visiobook_mobile/features/projects/data/project_service.dart';
 import 'package:visiobook_mobile/features/projects/domain/project.dart';
 
@@ -29,11 +30,111 @@ class ProjectProvider extends ChangeNotifier {
   List<Project> get draftProjects =>
       _projects.where((p) => p.status != ProjectStatus.ready).toList();
 
+  /// Donnees mock pour tester l'UI
+  static final List<Project> _mockProjects = [
+    // Projets ready (VisioBooks termines)
+    Project(
+      id: '1',
+      title: 'Le Petit Prince',
+      description: 'Un conte poetique et philosophique',
+      status: ProjectStatus.ready,
+      coverUrl: 'https://picsum.photos/seed/prince/300/400',
+      videoUrl: 'https://example.com/video1.mp4',
+      createdAt: DateTime.now().subtract(const Duration(days: 2)),
+      updatedAt: DateTime.now().subtract(const Duration(days: 1)),
+    ),
+    Project(
+      id: '2',
+      title: 'Les Miserables',
+      description: 'Le chef-d\'oeuvre de Victor Hugo',
+      status: ProjectStatus.ready,
+      coverUrl: 'https://picsum.photos/seed/miserables/300/400',
+      videoUrl: 'https://example.com/video2.mp4',
+      createdAt: DateTime.now().subtract(const Duration(days: 5)),
+      updatedAt: DateTime.now().subtract(const Duration(days: 3)),
+    ),
+    Project(
+      id: '5',
+      title: 'L\'Etranger',
+      description: 'Roman d\'Albert Camus',
+      status: ProjectStatus.ready,
+      coverUrl: 'https://picsum.photos/seed/etranger/300/400',
+      videoUrl: 'https://example.com/video5.mp4',
+      createdAt: DateTime.now().subtract(const Duration(days: 10)),
+      updatedAt: DateTime.now().subtract(const Duration(days: 8)),
+    ),
+    Project(
+      id: '6',
+      title: 'Madame Bovary',
+      description: 'Chef-d\'oeuvre de Flaubert',
+      status: ProjectStatus.ready,
+      coverUrl: 'https://picsum.photos/seed/bovary/300/400',
+      videoUrl: 'https://example.com/video6.mp4',
+      createdAt: DateTime.now().subtract(const Duration(days: 15)),
+      updatedAt: DateTime.now().subtract(const Duration(days: 12)),
+    ),
+    Project(
+      id: '7',
+      title: 'Notre-Dame de Paris',
+      description: 'Roman de Victor Hugo',
+      status: ProjectStatus.ready,
+      coverUrl: 'https://picsum.photos/seed/notredame/300/400',
+      videoUrl: 'https://example.com/video7.mp4',
+      createdAt: DateTime.now().subtract(const Duration(days: 20)),
+      updatedAt: DateTime.now().subtract(const Duration(days: 18)),
+    ),
+    // Projets en cours
+    Project(
+      id: '3',
+      title: 'Germinal',
+      description: 'Roman de Emile Zola',
+      status: ProjectStatus.processing,
+      coverUrl: 'https://picsum.photos/seed/germinal/300/400',
+      createdAt: DateTime.now().subtract(const Duration(hours: 2)),
+      updatedAt: DateTime.now(),
+    ),
+    Project(
+      id: '4',
+      title: 'Mon nouveau projet',
+      description: 'Brouillon en cours',
+      status: ProjectStatus.draft,
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    ),
+    Project(
+      id: '8',
+      title: 'Candide',
+      description: 'Conte philosophique de Voltaire',
+      status: ProjectStatus.processing,
+      coverUrl: 'https://picsum.photos/seed/candide/300/400',
+      createdAt: DateTime.now().subtract(const Duration(hours: 5)),
+      updatedAt: DateTime.now().subtract(const Duration(hours: 1)),
+    ),
+    Project(
+      id: '9',
+      title: 'Le Rouge et le Noir',
+      description: 'Roman de Stendhal',
+      status: ProjectStatus.draft,
+      coverUrl: 'https://picsum.photos/seed/rouge/300/400',
+      createdAt: DateTime.now().subtract(const Duration(days: 1)),
+      updatedAt: DateTime.now().subtract(const Duration(hours: 6)),
+    ),
+  ];
+
   /// Charge tous les projets
   Future<void> loadProjects() async {
     _state = ProjectsState.loading;
     _error = null;
     notifyListeners();
+
+    // Mode mock: retourner des donnees fictives
+    if (EnvironmentConfig.useMockData) {
+      await Future.delayed(const Duration(milliseconds: 500));
+      _projects = _mockProjects;
+      _state = ProjectsState.loaded;
+      notifyListeners();
+      return;
+    }
 
     final result = await _projectService.getProjects();
 

--- a/lib/features/projects/presentation/providers/project_provider.dart
+++ b/lib/features/projects/presentation/providers/project_provider.dart
@@ -129,7 +129,6 @@ class ProjectProvider extends ChangeNotifier {
 
     // Mode mock: retourner des donnees fictives
     if (EnvironmentConfig.useMockData) {
-      await Future.delayed(const Duration(milliseconds: 500));
       _projects = _mockProjects;
       _state = ProjectsState.loaded;
       notifyListeners();

--- a/lib/features/projects/presentation/screens/dashboard_screen.dart
+++ b/lib/features/projects/presentation/screens/dashboard_screen.dart
@@ -189,6 +189,9 @@ class _DashboardScreenState extends State<DashboardScreen> {
   }
 
   Widget _buildHeader(BuildContext context) {
+    final userName = context.watch<AuthProvider>().userName;
+    final greeting = userName != null ? 'Bonjour, $userName !' : 'Bonjour !';
+
     return Padding(
       padding: const EdgeInsets.all(24),
       child: Row(
@@ -212,7 +215,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  'Bonjour !',
+                  greeting,
                   style: Theme.of(context).textTheme.headlineSmall,
                 ),
                 const SizedBox(height: 2),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -4,7 +4,10 @@ import 'package:visiobook_mobile/main.dart';
 void main() {
   testWidgets('App should start without errors', (WidgetTester tester) async {
     await tester.pumpWidget(const VisioBookApp());
-    await tester.pumpAndSettle();
+
+    // Pump pour laisser l'app s'initialiser
+    await tester.pump();
+    await tester.pump();
 
     // L'app devrait demarrer sans erreur
     expect(find.byType(VisioBookApp), findsOneWidget);


### PR DESCRIPTION
- Add useMockData flag in environment config
- Auto-login in mock mode (bypass auth check)
- Return mock projects (9 books with different statuses)
- Skip router redirect in mock mode
- Add note in TASKS.md about disabling mock for production