### PR TITLE
feat(auth): connect login and register to core-user-service API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,85 @@
-# visiobook_mobile
+# VisioBook Mobile
 
-A new Flutter project.
+Application mobile Flutter pour VisioBook - transformez vos textes en videos grace a l'IA.
 
-## Getting Started
+## Prerequis
 
-This project is a starting point for a Flutter application.
+- Flutter SDK >= 3.10.7
+- Dart SDK
+- Xcode (macOS/iOS) avec signing configure
+- Android Studio (Android)
 
-A few resources to get you started if this is your first Flutter project:
+## Installation
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+```bash
+make install
+```
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+## Lancement
+
+```bash
+make run-macos    # macOS
+make run-ios      # iOS
+make run-android  # Android
+```
+
+## Commandes utiles
+
+```bash
+make check     # Format + Analyze + Test
+make format    # Formate le code Dart
+make analyze   # Analyse statique (lint)
+make test      # Lance les tests
+make ci        # Simulation CI complete
+```
+
+Voir `make help` pour la liste complete.
+
+## Architecture
+
+```
+lib/
+├── config/          # Configuration environnement (dev/prod)
+├── core/
+│   ├── network/     # Client HTTP (Dio) avec intercepteurs
+│   ├── routing/     # Navigation (GoRouter)
+│   ├── theme/       # Theme et Design System
+│   ├── utils/       # Validators, Secure Storage
+│   └── widgets/     # Composants reutilisables (AppButton, AppInput, BottomNavBar)
+└── features/
+    ├── auth/        # Authentification (login, register, splash)
+    ├── projects/    # Dashboard et liste des projets
+    ├── project_detail/ # Configuration projet (style, langue, duree)
+    ├── import/      # Import de fichiers (PDF, TXT, DOCX, EPUB)
+    └── player/      # Lecteur video avec selecteur de generation
+```
+
+## Configuration API
+
+Les URLs des microservices sont configurees dans `lib/config/environment.dart` :
+
+| Service | Port | Role |
+|---------|------|------|
+| Core User Service | 9999 | Auth, profils |
+| Core Project Service | 8086 | Projets, workflows |
+| Support Storage Service | 8089 | Upload, stockage, streaming |
+| AI Analysis Service | 8083 | Analyse IA, generation |
+
+## Configuration macOS
+
+Pour le developpement macOS, ouvrir Xcode une fois pour configurer la signature :
+
+```bash
+open macos/Runner.xcworkspace
+```
+
+Puis dans **Signing & Capabilities** : activer **Automatically manage signing** et selectionner votre Team.
+
+## Stack technique
+
+- **State Management** : Provider
+- **Navigation** : GoRouter
+- **HTTP** : Dio avec token refresh automatique
+- **Stockage** : Flutter Secure Storage (Keychain/Encrypted SharedPrefs)
+- **Video** : Chewie + video_player
+- **Icons** : Lucide Icons

--- a/TASKS.md
+++ b/TASKS.md
@@ -11,7 +11,7 @@
 | 0 | Setup Projet | P0 | Done | 100% |
 | 1 | CI/CD | P0 | Done | 100% |
 | 2 | Core / Infrastructure | P0 | Done | 100% |
-| 3 | Authentification | P0 | In Progress | 60% |
+| 3 | Authentification | P0 | In Progress | 80% |
 | 4 | Dashboard | P0 | In Progress | 60% |
 | 5 | Import Contenu | P0 | In Progress | 60% |
 | 6 | Detail & Configuration | P0 | In Progress | 80% |
@@ -25,8 +25,8 @@
 
 ## Note importante
 
-> **MOCK DATA ACTIVE** : Pour tester l'UI sans backend, le mode mock est active dans `lib/config/environment.dart`.
-> Avant de connecter aux vrais microservices, mettre `useMockData = false`.
+> **AUTH CONNECTEE** : L'authentification est connectee au Core User Service (51.178.52.51:9999).
+> `useMockData = false` dans `lib/config/environment.dart`. Les autres services ne sont pas encore disponibles.
 
 ---
 
@@ -85,7 +85,7 @@
 ## Phase 3: Authentification [P0]
 
 > Ref: doc/04-mvp-screens.md - Ecrans 1 & 2
-> API: Core User Service (port 8081)
+> API: Core User Service (port 9999)
 
 ### Splash Screen [P0]
 - [x] Widget SplashScreen
@@ -109,7 +109,8 @@
 - [x] Gestion etats (loading, error, success)
 
 ### Register Screen [P0]
-- [x] Champ prenom
+- [x] Champ nom d'utilisateur
+- [x] Champ prenom + nom
 - [x] Champ email avec validation
 - [x] Champ mot de passe (8 chars, 1 maj, 1 chiffre)
 - [ ] Checkbox CGU
@@ -117,8 +118,8 @@
 - [ ] Ecran verification email
 
 ### API Endpoints [P0]
-- [x] POST /api/v1/auth/register
-- [x] POST /api/v1/auth/login
+- [x] POST /api/v1/auth/register (connecte au cluster)
+- [x] POST /api/v1/auth/login (connecte au cluster)
 - [x] POST /api/v1/auth/refresh
 - [ ] POST /api/v1/auth/verify
 
@@ -371,7 +372,7 @@
 
 | Service | Port | Role |
 |---------|------|------|
-| Core User Service | 8081 | Auth, profils, sessions |
+| Core User Service | 9999 | Auth, profils, sessions |
 | Core Project Service | 8086 | Projets, workflows |
 | Support Storage Service | 8089 | Upload, stockage, streaming |
 | AI Analysis Service | 8083 | Analyse IA, generation |

--- a/lib/config/environment.dart
+++ b/lib/config/environment.dart
@@ -5,7 +5,7 @@ class EnvironmentConfig {
   static Environment _current = Environment.dev;
 
   /// Mode mock pour tester l'UI sans backend
-  static bool useMockData = true;
+  static bool useMockData = false;
 
   static Environment get current => _current;
 
@@ -17,14 +17,14 @@ class EnvironmentConfig {
   static String get apiBaseUrl {
     switch (_current) {
       case Environment.dev:
-        return 'http://localhost';
+        return 'http://51.178.52.51';
       case Environment.prod:
         return 'https://api.visiobook.com';
     }
   }
 
-  /// Core User Service (port 8081)
-  static String get userServiceUrl => '$apiBaseUrl:8081/api/v1';
+  /// Core User Service (port 9999)
+  static String get userServiceUrl => '$apiBaseUrl:9999/api/v1';
 
   /// Core Project Service (port 8086)
   static String get projectServiceUrl => '$apiBaseUrl:8086/api/v1';

--- a/lib/core/network/api_client.dart
+++ b/lib/core/network/api_client.dart
@@ -129,8 +129,8 @@ class _AuthInterceptor extends Interceptor {
             data: {'refreshToken': refreshToken},
           );
 
-          final newAccessToken = response.data['accessToken'] as String?;
-          final newRefreshToken = response.data['refreshToken'] as String?;
+          final newAccessToken = response.data['access_token'] as String?;
+          final newRefreshToken = response.data['refresh_token'] as String?;
 
           if (newAccessToken != null) {
             await _storage.saveAccessToken(newAccessToken);

--- a/lib/core/utils/validators.dart
+++ b/lib/core/utils/validators.dart
@@ -68,6 +68,44 @@ class Validators {
     return null;
   }
 
+  /// Valide un nom de famille
+  static String? lastName(String? value) {
+    if (value == null || value.isEmpty) {
+      return 'Nom requis';
+    }
+
+    if (value.length < 2) {
+      return 'Minimum 2 caracteres';
+    }
+
+    if (value.length > 50) {
+      return 'Maximum 50 caracteres';
+    }
+
+    return null;
+  }
+
+  /// Valide un nom d'utilisateur
+  static String? username(String? value) {
+    if (value == null || value.isEmpty) {
+      return 'Nom d\'utilisateur requis';
+    }
+
+    if (value.length < 3) {
+      return 'Minimum 3 caracteres';
+    }
+
+    if (value.length > 30) {
+      return 'Maximum 30 caracteres';
+    }
+
+    if (!RegExp(r'^[a-zA-Z0-9_]+$').hasMatch(value)) {
+      return 'Lettres, chiffres et underscores uniquement';
+    }
+
+    return null;
+  }
+
   /// Valide un champ requis
   static String? required(String? value, [String fieldName = 'Ce champ']) {
     if (value == null || value.isEmpty) {

--- a/lib/features/auth/data/auth_service.dart
+++ b/lib/features/auth/data/auth_service.dart
@@ -34,13 +34,12 @@ class AuthService {
       });
 
       final data = response.data;
-      final accessToken = data['accessToken'] as String?;
-      final refreshToken = data['refreshToken'] as String?;
-      final userId = data['userId'] as String?;
+      final accessToken = data['access_token'] as String?;
 
-      if (accessToken != null && refreshToken != null) {
+      if (accessToken != null) {
         await _storage.saveAccessToken(accessToken);
-        await _storage.saveRefreshToken(refreshToken);
+        // Extraire le userId du JWT si present
+        final userId = _extractUserIdFromJwt(accessToken);
         if (userId != null) {
           await _storage.saveUserId(userId);
         }
@@ -57,32 +56,36 @@ class AuthService {
 
   /// Inscription
   Future<AuthResult> register({
-    required String firstName,
+    required String username,
     required String email,
     required String password,
+    required String firstName,
+    required String lastName,
   }) async {
     try {
       final response = await _apiClient.authRegister({
-        'firstName': firstName,
         'email': email,
+        'username': username,
         'password': password,
+        'first_name': firstName,
+        'last_name': lastName,
+        'role': 'user',
       });
 
       final data = response.data;
-      final accessToken = data['accessToken'] as String?;
-      final refreshToken = data['refreshToken'] as String?;
-      final userId = data['userId'] as String?;
+      final accessToken = data['access_token'] as String?;
 
-      if (accessToken != null && refreshToken != null) {
+      if (accessToken != null) {
         await _storage.saveAccessToken(accessToken);
-        await _storage.saveRefreshToken(refreshToken);
+        final userId = _extractUserIdFromJwt(accessToken);
         if (userId != null) {
           await _storage.saveUserId(userId);
         }
         return AuthResult(success: true, userId: userId);
       }
 
-      return AuthResult(success: false, error: 'Reponse invalide du serveur');
+      // Si pas de token dans la reponse register, login automatique
+      return login(email: email, password: password);
     } on DioException catch (e) {
       return _handleDioError(e);
     } catch (e) {
@@ -100,6 +103,43 @@ class AuthService {
     return _storage.isLoggedIn();
   }
 
+  /// Extrait le sub (userId) du JWT sans verification de signature
+  String? _extractUserIdFromJwt(String token) {
+    try {
+      final parts = token.split('.');
+      if (parts.length != 3) return null;
+
+      // Decoder le payload (base64url)
+      String payload = parts[1];
+      // Ajouter le padding base64 si necessaire
+      switch (payload.length % 4) {
+        case 2:
+          payload += '==';
+          break;
+        case 3:
+          payload += '=';
+          break;
+      }
+      final decoded = Uri.decodeFull(
+        String.fromCharCodes(_base64UrlDecode(payload)),
+      );
+
+      // Parser le JSON
+      final regex = RegExp(r'"sub"\s*:\s*"([^"]+)"');
+      final match = regex.firstMatch(decoded);
+      return match?.group(1);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  List<int> _base64UrlDecode(String input) {
+    String normalized = input.replaceAll('-', '+').replaceAll('_', '/');
+    return List<int>.from(
+      Uri.parse('data:;base64,$normalized').data!.contentAsBytes(),
+    );
+  }
+
   /// Gestion des erreurs Dio
   AuthResult _handleDioError(DioException e) {
     if (e.response != null) {
@@ -107,8 +147,12 @@ class AuthService {
       final data = e.response!.data;
 
       String message = 'Erreur serveur';
-      if (data is Map && data['message'] != null) {
-        message = data['message'];
+      if (data is Map) {
+        if (data['detail'] != null) {
+          message = data['detail'].toString();
+        } else if (data['message'] != null) {
+          message = data['message'].toString();
+        }
       }
 
       switch (statusCode) {
@@ -122,15 +166,12 @@ class AuthService {
         case 409:
           return AuthResult(
             success: false,
-            error: 'Cet email est deja utilise',
+            error: 'Cet email ou nom d\'utilisateur est deja utilise',
           );
         case 422:
           return AuthResult(success: false, error: 'Donnees invalides');
         default:
-          return AuthResult(
-            success: false,
-            error: 'Erreur serveur ($statusCode)',
-          );
+          return AuthResult(success: false, error: message);
       }
     }
 

--- a/lib/features/auth/presentation/providers/auth_provider.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.dart
@@ -11,7 +11,7 @@ class AuthProvider extends ChangeNotifier {
 
   AuthState _state = AuthState.initial;
   String? _error;
-  String? _mockUserName;
+  String? _userName;
 
   AuthProvider({required AuthService authService}) : _authService = authService;
 
@@ -19,14 +19,14 @@ class AuthProvider extends ChangeNotifier {
   String? get error => _error;
   bool get isLoading => _state == AuthState.loading;
   bool get isAuthenticated => _state == AuthState.authenticated;
-  String? get userName => _mockUserName;
+  String? get userName => _userName;
 
   /// Verifie l'etat de connexion au demarrage
   Future<void> checkAuthStatus() async {
     // Mode mock: auto-login
     if (EnvironmentConfig.useMockData) {
       _state = AuthState.authenticated;
-      _mockUserName = 'Marine';
+      _userName = 'Marine';
       notifyListeners();
       return;
     }
@@ -62,22 +62,27 @@ class AuthProvider extends ChangeNotifier {
 
   /// Inscription
   Future<bool> register({
-    required String firstName,
+    required String username,
     required String email,
     required String password,
+    required String firstName,
+    required String lastName,
   }) async {
     _state = AuthState.loading;
     _error = null;
     notifyListeners();
 
     final result = await _authService.register(
-      firstName: firstName,
+      username: username,
       email: email,
       password: password,
+      firstName: firstName,
+      lastName: lastName,
     );
 
     if (result.success) {
       _state = AuthState.authenticated;
+      _userName = username;
       notifyListeners();
       return true;
     } else {
@@ -92,6 +97,7 @@ class AuthProvider extends ChangeNotifier {
   Future<void> logout() async {
     await _authService.logout();
     _state = AuthState.unauthenticated;
+    _userName = null;
     _error = null;
     notifyListeners();
   }

--- a/lib/features/auth/presentation/screens/register_screen.dart
+++ b/lib/features/auth/presentation/screens/register_screen.dart
@@ -17,7 +17,9 @@ class RegisterScreen extends StatefulWidget {
 
 class _RegisterScreenState extends State<RegisterScreen> {
   final _formKey = GlobalKey<FormState>();
+  final _usernameController = TextEditingController();
   final _firstNameController = TextEditingController();
+  final _lastNameController = TextEditingController();
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
   final _confirmPasswordController = TextEditingController();
@@ -26,7 +28,9 @@ class _RegisterScreenState extends State<RegisterScreen> {
 
   @override
   void dispose() {
+    _usernameController.dispose();
     _firstNameController.dispose();
+    _lastNameController.dispose();
     _emailController.dispose();
     _passwordController.dispose();
     _confirmPasswordController.dispose();
@@ -39,7 +43,9 @@ class _RegisterScreenState extends State<RegisterScreen> {
     final authProvider = context.read<AuthProvider>();
 
     final success = await authProvider.register(
+      username: _usernameController.text.trim(),
       firstName: _firstNameController.text.trim(),
+      lastName: _lastNameController.text.trim(),
       email: _emailController.text.trim(),
       password: _passwordController.text,
     );
@@ -103,12 +109,38 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       const SizedBox(height: 24),
                     ],
                     AppInput(
-                      label: 'Prenom',
-                      placeholder: 'Votre prenom',
-                      controller: _firstNameController,
-                      keyboardType: TextInputType.name,
-                      validator: Validators.firstName,
+                      label: 'Nom d\'utilisateur',
+                      placeholder: 'Votre nom d\'utilisateur',
+                      controller: _usernameController,
+                      keyboardType: TextInputType.text,
+                      validator: Validators.username,
                       enabled: !authProvider.isLoading,
+                    ),
+                    const SizedBox(height: 20),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: AppInput(
+                            label: 'Prenom',
+                            placeholder: 'Votre prenom',
+                            controller: _firstNameController,
+                            keyboardType: TextInputType.name,
+                            validator: Validators.firstName,
+                            enabled: !authProvider.isLoading,
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: AppInput(
+                            label: 'Nom',
+                            placeholder: 'Votre nom',
+                            controller: _lastNameController,
+                            keyboardType: TextInputType.name,
+                            validator: Validators.lastName,
+                            enabled: !authProvider.isLoading,
+                          ),
+                        ),
+                      ],
                     ),
                     const SizedBox(height: 20),
                     AppInput(

--- a/lib/features/projects/presentation/providers/project_provider.dart
+++ b/lib/features/projects/presentation/providers/project_provider.dart
@@ -214,12 +214,11 @@ class ProjectProvider extends ChangeNotifier {
 
     if (result.success && result.data != null) {
       _projects = result.data!;
-      _state = ProjectsState.loaded;
     } else {
-      _error = result.error;
-      _state = ProjectsState.error;
+      // Si le service n'est pas disponible, afficher une liste vide
+      _projects = [];
     }
-
+    _state = ProjectsState.loaded;
     notifyListeners();
   }
 

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -204,7 +204,6 @@
 				E781E33D2ECCA39A7708F5A4 /* Pods-RunnerTests.release.xcconfig */,
 				AA284A9A4B3F8C28539B9F1F /* Pods-RunnerTests.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -270,7 +269,6 @@
 					33CC10EC2044A3C60003C045 = {
 						CreatedOnToolsVersion = 9.2;
 						LastSwiftMigration = 1100;
-						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.Sandbox = {
 								enabled = 1;
@@ -572,8 +570,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = Y722PU9YX7;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -704,8 +704,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = Y722PU9YX7;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -724,8 +726,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = Y722PU9YX7;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,11 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.visiobook.visiobookMobile</string>
+	</array>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -4,5 +4,11 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.visiobook.visiobookMobile</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
- Point user service to cluster
- Adapt auth to real API format (access_token, username, first_name, last_name)
- Extract userId from JWT payload
- Handle API error responses via 'detail' field
- Add username and lastName validators
- Update register screen with username, first name, and last name fields
- Add macOS network client and keychain entitlements
- Gracefully handle unavailable project service on dashboard