### PR TITLE
fix: correct MIME type for scanned images and align scan flow with file import

### DIFF
--- a/lib/features/import/data/storage_service.dart
+++ b/lib/features/import/data/storage_service.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:dio/dio.dart';
+import 'package:http_parser/http_parser.dart';
 import 'package:visiobook_mobile/config/environment.dart';
 import 'package:visiobook_mobile/core/network/api_client.dart';
 import 'package:visiobook_mobile/features/import/domain/import_file.dart';
@@ -33,10 +34,15 @@ class StorageService {
         return StorageResult(success: false, error: 'Fichier introuvable');
       }
 
+      final contentType = importFile.type.mimeType != null
+          ? MediaType.parse(importFile.type.mimeType!)
+          : null;
+
       final formData = FormData.fromMap({
         'file': await MultipartFile.fromFile(
           importFile.path,
           filename: importFile.name,
+          contentType: contentType,
         ),
         'project_id': projectId ?? '',
       });

--- a/lib/features/import/domain/import_file.dart
+++ b/lib/features/import/domain/import_file.dart
@@ -4,6 +4,9 @@ enum ImportFileType {
   txt,
   docx,
   epub,
+  jpeg,
+  png,
+  gif,
   unknown;
 
   static ImportFileType fromExtension(String extension) {
@@ -16,6 +19,13 @@ enum ImportFileType {
         return ImportFileType.docx;
       case 'epub':
         return ImportFileType.epub;
+      case 'jpg':
+      case 'jpeg':
+        return ImportFileType.jpeg;
+      case 'png':
+        return ImportFileType.png;
+      case 'gif':
+        return ImportFileType.gif;
       default:
         return ImportFileType.unknown;
     }
@@ -31,10 +41,44 @@ enum ImportFileType {
         return 'Word';
       case ImportFileType.epub:
         return 'EPUB';
+      case ImportFileType.jpeg:
+        return 'JPEG';
+      case ImportFileType.png:
+        return 'PNG';
+      case ImportFileType.gif:
+        return 'GIF';
       case ImportFileType.unknown:
         return 'Inconnu';
     }
   }
+
+  /// Type MIME correspondant
+  String? get mimeType {
+    switch (this) {
+      case ImportFileType.pdf:
+        return 'application/pdf';
+      case ImportFileType.txt:
+        return 'text/plain';
+      case ImportFileType.docx:
+        return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+      case ImportFileType.epub:
+        return 'application/epub+zip';
+      case ImportFileType.jpeg:
+        return 'image/jpeg';
+      case ImportFileType.png:
+        return 'image/png';
+      case ImportFileType.gif:
+        return 'image/gif';
+      case ImportFileType.unknown:
+        return null;
+    }
+  }
+
+  /// Vrai si c'est un type image
+  bool get isImage =>
+      this == ImportFileType.jpeg ||
+      this == ImportFileType.png ||
+      this == ImportFileType.gif;
 }
 
 /// Represente un fichier importe
@@ -70,7 +114,7 @@ class ImportFile {
   /// Validation: fichier < 50MB
   bool get isValidSize => sizeBytes <= 50 * 1024 * 1024;
 
-  /// Validation: format supporte
+  /// Validation: format supporte (documents et images)
   bool get isValidFormat => type != ImportFileType.unknown;
 }
 

--- a/lib/features/import/presentation/providers/import_provider.dart
+++ b/lib/features/import/presentation/providers/import_provider.dart
@@ -216,6 +216,7 @@ Finalement, le petit prince arriva sur Terre, ou il rencontra un renard qui lui 
   }
 
   /// Upload des images scannees (via camera)
+  /// Meme flux que uploadFile : upload + extract texte (OCR) + ingestion
   Future<bool> uploadScannedImages(List<String> imagePaths) async {
     if (imagePaths.isEmpty) {
       _error = 'Aucune image capturee';
@@ -229,58 +230,90 @@ Finalement, le petit prince arriva sur Terre, ou il rencontra un renard qui lui 
     _error = null;
     notifyListeners();
 
+    // Mode mock: simuler l'upload
+    if (EnvironmentConfig.useMockData) {
+      _selectedFile = ImportFile(
+        name: 'scan_${DateTime.now().millisecondsSinceEpoch}.jpg',
+        path: imagePaths.first,
+        type: ImportFileType.jpeg,
+        sizeBytes: 0,
+        selectedAt: DateTime.now(),
+      );
+      await _mockUpload();
+      return true;
+    }
+
     try {
       final totalImages = imagePaths.length;
-      StorageResult<UploadResult>? lastResult;
+      String? firstFileId;
 
       for (int i = 0; i < totalImages; i++) {
         final file = File(imagePaths[i]);
+        final ext = imagePaths[i].split('.').last.toLowerCase();
+        final fileType = ImportFileType.fromExtension(ext);
         final fileName =
-            'scan_${DateTime.now().millisecondsSinceEpoch}_${i + 1}.jpg';
+            'scan_${DateTime.now().millisecondsSinceEpoch}_${i + 1}.$ext';
         final fileSize = await file.length();
 
         _selectedFile = ImportFile(
           name: fileName,
           path: imagePaths[i],
-          type: ImportFileType.unknown,
+          type: fileType == ImportFileType.unknown
+              ? ImportFileType.jpeg
+              : fileType,
           sizeBytes: fileSize,
           selectedAt: DateTime.now(),
         );
 
-        // Mode mock: simuler l'upload
-        if (EnvironmentConfig.useMockData) {
-          await _mockUpload();
-          return true;
-        }
-
-        lastResult = await _storageService.uploadFile(
+        // Upload
+        final uploadResult = await _storageService.uploadFile(
           _selectedFile!,
           onProgress: (progress) {
-            _uploadProgress = (i + progress) / totalImages;
+            _uploadProgress = (i + progress) / totalImages * 0.9;
             notifyListeners();
           },
         );
 
-        if (!lastResult.success) {
-          _error = lastResult.error;
+        if (!uploadResult.success || uploadResult.data == null) {
+          _error = uploadResult.error;
           _state = ImportState.error;
           notifyListeners();
           return false;
         }
+
+        firstFileId ??= uploadResult.data!.fileId;
       }
 
-      if (lastResult != null && lastResult.success && lastResult.data != null) {
-        _uploadResult = lastResult.data;
-        _uploadProgress = 1.0;
-        _state = ImportState.uploaded;
+      // Lancer l'ingestion (le backend fait l'OCR)
+      if (firstFileId != null && firstFileId.isNotEmpty) {
+        _uploadProgress = 0.95;
         notifyListeners();
-        return true;
+        final ingestionResult = await _storageService.startIngestion(
+          fileId: firstFileId,
+          projectId: '',
+        );
+        if (ingestionResult.success && ingestionResult.data != null) {
+          _lastIngestionJobId = ingestionResult.data;
+          _lastIngestionFileId = firstFileId;
+        }
       }
 
-      _error = lastResult?.error ?? 'Erreur inconnue';
-      _state = ImportState.error;
+      _selectedFile = ImportFile(
+        name: 'Scan $totalImages page${totalImages > 1 ? 's' : ''}',
+        path: imagePaths.first,
+        type: ImportFileType.jpeg,
+        sizeBytes: 0,
+        selectedAt: DateTime.now(),
+      );
+
+      _uploadResult = UploadResult.success(
+        fileId: firstFileId ?? '',
+        fileUrl: '',
+      );
+      _uploadProgress = 1.0;
+      _state = ImportState.uploaded;
       notifyListeners();
-      return false;
+      return true;
     } catch (e) {
       _error = 'Erreur lors du traitement du scan: $e';
       _state = ImportState.error;

--- a/lib/features/import/presentation/screens/file_import_screen.dart
+++ b/lib/features/import/presentation/screens/file_import_screen.dart
@@ -296,6 +296,10 @@ class _FileSelectedCard extends StatelessWidget {
         return LucideIcons.fileText;
       case ImportFileType.epub:
         return LucideIcons.bookOpen;
+      case ImportFileType.jpeg:
+      case ImportFileType.png:
+      case ImportFileType.gif:
+        return LucideIcons.image;
       case ImportFileType.unknown:
         return LucideIcons.file;
     }

--- a/lib/features/import/presentation/screens/scanner_screen.dart
+++ b/lib/features/import/presentation/screens/scanner_screen.dart
@@ -10,8 +10,8 @@ import 'package:visiobook_mobile/core/routing/app_router.dart';
 import 'package:visiobook_mobile/core/theme/app_theme.dart';
 import 'package:visiobook_mobile/core/widgets/app_button.dart';
 import 'package:visiobook_mobile/core/widgets/gradient_background.dart';
+import 'package:visiobook_mobile/features/history/presentation/providers/texts_provider.dart';
 import 'package:visiobook_mobile/features/import/presentation/providers/import_provider.dart';
-import 'package:visiobook_mobile/features/project_detail/presentation/providers/project_detail_provider.dart';
 
 /// Ecran de scan de document via la camera
 class ScannerScreen extends StatefulWidget {
@@ -203,18 +203,19 @@ class _ScannerScreenState extends State<ScannerScreen>
       if (!mounted) return;
 
       if (provider.state == ImportState.uploaded) {
-        final result = provider.uploadResult;
-        final file = provider.selectedFile;
-        if (result != null && file != null) {
-          context.read<ProjectDetailProvider>().initFromImport(
-            fileId: result.fileId ?? 'unknown',
-            fileName: file.name,
-            extractedText: result.extractedText,
-            wordCount: result.wordCount,
+        // Lancer le tracking d'ingestion
+        final jobId = provider.lastIngestionJobId;
+        final fileId = provider.lastIngestionFileId;
+        if (jobId != null && fileId != null) {
+          context.read<TextsProvider>().startIngestionTracking(
+            fileId,
+            jobId,
+            provider.selectedFile?.name ?? 'Scan',
           );
-          provider.reset();
-          context.push(AppRoutes.projectConfig);
         }
+        provider.reset();
+        // Retour au dashboard — l'ingestion tourne en background
+        context.go(AppRoutes.dashboard);
       } else if (provider.state == ImportState.error) {
         setState(() {
           _isUploading = false;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -417,7 +417,7 @@ packages:
     source: hosted
     version: "1.6.0"
   http_parser:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http_parser
       sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,6 +62,7 @@ dependencies:
   flutter_stripe: ^12.4.0
   url_launcher: ^6.2.0
   flutter_local_notifications: ^21.0.0
+  http_parser: ^4.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Add jpeg/png/gif to ImportFileType with mimeType getter
- Send correct contentType in MultipartFile upload
- Scan flow: upload + start ingestion (backend handles OCR)
- Redirect scanner to dashboard with ingestion tracking
- Tested against real content-ingestion-service: upload → ingestion → completed

Closes #41