### PR TITLE
feat: prepare forgot/reset password flow with coming soon placeholder

### DIFF
--- a/lib/core/network/api_client.dart
+++ b/lib/core/network/api_client.dart
@@ -46,6 +46,24 @@ class ApiClient {
     data: {'token': token},
   );
 
+  Future<Response> forgotPassword(String email) => _dio.post(
+    '${EnvironmentConfig.userServiceUrl}/users/forgot-password',
+    data: {'email': email},
+  );
+
+  Future<Response> resetPassword({
+    required String resetToken,
+    required String newPassword,
+    required String confirmPassword,
+  }) => _dio.post(
+    '${EnvironmentConfig.userServiceUrl}/users/reset-password',
+    data: {
+      'reset_token': resetToken,
+      'new_password': newPassword,
+      'confirm_password': confirmPassword,
+    },
+  );
+
   // Project Service
   Future<Response> getProjects() =>
       _dio.get('${EnvironmentConfig.projectServiceUrl}/projects');

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -8,6 +8,7 @@ import 'package:visiobook_mobile/features/auth/presentation/screens/login_screen
 import 'package:visiobook_mobile/features/auth/presentation/screens/onboarding_screen.dart';
 import 'package:visiobook_mobile/features/auth/presentation/screens/forgot_password_screen.dart';
 import 'package:visiobook_mobile/features/auth/presentation/screens/register_screen.dart';
+import 'package:visiobook_mobile/features/auth/presentation/screens/reset_password_screen.dart';
 import 'package:visiobook_mobile/features/import/presentation/screens/file_import_screen.dart';
 import 'package:visiobook_mobile/features/import/presentation/screens/input_mode_screen.dart';
 import 'package:visiobook_mobile/features/import/presentation/screens/scanner_screen.dart';
@@ -31,6 +32,7 @@ class AppRoutes {
   static const String onboarding = '/onboarding';
   static const String login = '/login';
   static const String forgotPassword = '/forgot-password';
+  static const String resetPassword = '/reset-password';
   static const String register = '/register';
   static const String dashboard = '/dashboard';
   static const String projectView = '/project/:id';
@@ -83,6 +85,10 @@ class AppRouter {
       GoRoute(
         path: AppRoutes.forgotPassword,
         builder: (context, state) => const ForgotPasswordScreen(),
+      ),
+      GoRoute(
+        path: AppRoutes.resetPassword,
+        builder: (context, state) => const ResetPasswordScreen(),
       ),
       GoRoute(
         path: AppRoutes.register,
@@ -233,6 +239,7 @@ class AppRouter {
     final isOnAuth =
         state.matchedLocation == AppRoutes.login ||
         state.matchedLocation == AppRoutes.forgotPassword ||
+        state.matchedLocation == AppRoutes.resetPassword ||
         state.matchedLocation == AppRoutes.register;
 
     // Si on est sur splash ou onboarding, laisser l'ecran gerer la redirection

--- a/lib/features/auth/data/auth_service.dart
+++ b/lib/features/auth/data/auth_service.dart
@@ -123,6 +123,38 @@ class AuthService {
     }
   }
 
+  /// Demande un email de réinitialisation de mot de passe
+  Future<AuthResult> forgotPassword({required String email}) async {
+    try {
+      await _apiClient.forgotPassword(email);
+      return AuthResult(success: true);
+    } on DioException catch (e) {
+      return _handleDioError(e);
+    } catch (e) {
+      return AuthResult(success: false, error: 'Erreur inattendue: $e');
+    }
+  }
+
+  /// Réinitialise le mot de passe avec le token reçu par email
+  Future<AuthResult> resetPassword({
+    required String resetToken,
+    required String newPassword,
+    required String confirmPassword,
+  }) async {
+    try {
+      await _apiClient.resetPassword(
+        resetToken: resetToken,
+        newPassword: newPassword,
+        confirmPassword: confirmPassword,
+      );
+      return AuthResult(success: true);
+    } on DioException catch (e) {
+      return _handleDioError(e);
+    } catch (e) {
+      return AuthResult(success: false, error: 'Erreur inattendue: $e');
+    }
+  }
+
   /// Recupere le nom stocke localement
   Future<String?> getSavedUserName() async {
     return _storage.getUserName();

--- a/lib/features/auth/presentation/providers/auth_provider.dart
+++ b/lib/features/auth/presentation/providers/auth_provider.dart
@@ -142,4 +142,64 @@ class AuthProvider extends ChangeNotifier {
     }
     notifyListeners();
   }
+
+  /// Demande la réinitialisation du mot de passe
+  Future<bool> forgotPassword({required String email}) async {
+    _state = AuthState.loading;
+    _error = null;
+    notifyListeners();
+
+    if (EnvironmentConfig.useMockData) {
+      _state = AuthState.unauthenticated;
+      notifyListeners();
+      return true;
+    }
+
+    final result = await _authService.forgotPassword(email: email);
+
+    if (result.success) {
+      _state = AuthState.unauthenticated;
+      notifyListeners();
+      return true;
+    } else {
+      _state = AuthState.error;
+      _error = result.error;
+      notifyListeners();
+      return false;
+    }
+  }
+
+  /// Réinitialise le mot de passe
+  Future<bool> resetPassword({
+    required String resetToken,
+    required String newPassword,
+    required String confirmPassword,
+  }) async {
+    _state = AuthState.loading;
+    _error = null;
+    notifyListeners();
+
+    if (EnvironmentConfig.useMockData) {
+      _state = AuthState.unauthenticated;
+      notifyListeners();
+      return true;
+    }
+
+    final result = await _authService.resetPassword(
+      resetToken: resetToken,
+      newPassword: newPassword,
+      confirmPassword: confirmPassword,
+    );
+
+    if (result.success) {
+      _state = AuthState.unauthenticated;
+      notifyListeners();
+      return true;
+    } else {
+      _state = AuthState.error;
+      _error = result.error;
+      notifyListeners();
+      return false;
+    }
+  }
 }

--- a/lib/features/auth/presentation/screens/login_screen.dart
+++ b/lib/features/auth/presentation/screens/login_screen.dart
@@ -146,7 +146,16 @@ class _LoginScreenState extends State<LoginScreen> {
                       TextButton(
                         onPressed: authProvider.isLoading
                             ? null
-                            : () => context.push(AppRoutes.forgotPassword),
+                            : () {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                    content: Text(
+                                      'Cette fonctionnalité arrive bientôt !',
+                                    ),
+                                    duration: Duration(seconds: 2),
+                                  ),
+                                );
+                              },
                         child: Text(
                           'Mot de passe oublié ?',
                           style: TextStyle(

--- a/lib/features/auth/presentation/screens/reset_password_screen.dart
+++ b/lib/features/auth/presentation/screens/reset_password_screen.dart
@@ -8,22 +8,28 @@ import 'package:visiobook_mobile/core/utils/validators.dart';
 import 'package:visiobook_mobile/core/widgets/widgets.dart';
 import 'package:visiobook_mobile/features/auth/presentation/providers/auth_provider.dart';
 
-class ForgotPasswordScreen extends StatefulWidget {
-  const ForgotPasswordScreen({super.key});
+class ResetPasswordScreen extends StatefulWidget {
+  const ResetPasswordScreen({super.key});
 
   @override
-  State<ForgotPasswordScreen> createState() => _ForgotPasswordScreenState();
+  State<ResetPasswordScreen> createState() => _ResetPasswordScreenState();
 }
 
-class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
+class _ResetPasswordScreenState extends State<ResetPasswordScreen> {
   final _formKey = GlobalKey<FormState>();
-  final _emailController = TextEditingController();
-  bool _submitted = false;
+  final _tokenController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _confirmController = TextEditingController();
   bool _isLoading = false;
+  bool _success = false;
+  bool _obscurePassword = true;
+  bool _obscureConfirm = true;
 
   @override
   void dispose() {
-    _emailController.dispose();
+    _tokenController.dispose();
+    _passwordController.dispose();
+    _confirmController.dispose();
     super.dispose();
   }
 
@@ -33,15 +39,17 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
     setState(() => _isLoading = true);
 
     final provider = context.read<AuthProvider>();
-    final success = await provider.forgotPassword(
-      email: _emailController.text.trim(),
+    final success = await provider.resetPassword(
+      resetToken: _tokenController.text.trim(),
+      newPassword: _passwordController.text,
+      confirmPassword: _confirmController.text,
     );
 
     if (!mounted) return;
 
     setState(() {
       _isLoading = false;
-      if (success) _submitted = true;
+      if (success) _success = true;
     });
 
     if (!success && provider.error != null) {
@@ -71,7 +79,7 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
         body: SafeArea(
           child: SingleChildScrollView(
             padding: const EdgeInsets.symmetric(horizontal: 32),
-            child: _submitted ? _buildSuccessState() : _buildFormState(),
+            child: _success ? _buildSuccessState() : _buildFormState(),
           ),
         ),
       ),
@@ -85,28 +93,60 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
         children: [
           const SizedBox(height: 48),
           Text(
-            'Mot de passe oublié',
+            'Nouveau mot de passe',
             style: Theme.of(context).textTheme.displaySmall,
           ),
           const SizedBox(height: 16),
           Text(
-            'Entrez votre adresse email et nous vous enverrons un lien pour réinitialiser votre mot de passe.',
+            'Entrez le code reçu par email et choisissez un nouveau mot de passe.',
             textAlign: TextAlign.center,
             style: Theme.of(
               context,
             ).textTheme.bodyLarge?.copyWith(color: AppColors.neutral500),
           ),
-          const SizedBox(height: 48),
+          const SizedBox(height: 32),
           AppInput(
-            label: 'Email',
-            placeholder: 'votre@email.com',
-            controller: _emailController,
-            keyboardType: TextInputType.emailAddress,
-            validator: Validators.email,
+            label: 'Code de réinitialisation',
+            placeholder: 'Collez le code reçu par email',
+            controller: _tokenController,
+            validator: Validators.required,
+          ),
+          const SizedBox(height: 16),
+          AppInput(
+            label: 'Nouveau mot de passe',
+            placeholder: '••••••••',
+            controller: _passwordController,
+            obscureText: _obscurePassword,
+            validator: Validators.password,
+            suffixIcon: IconButton(
+              icon: Icon(
+                _obscurePassword ? LucideIcons.eyeOff : LucideIcons.eye,
+                size: 20,
+              ),
+              onPressed: () =>
+                  setState(() => _obscurePassword = !_obscurePassword),
+            ),
+          ),
+          const SizedBox(height: 16),
+          AppInput(
+            label: 'Confirmer le mot de passe',
+            placeholder: '••••••••',
+            controller: _confirmController,
+            obscureText: _obscureConfirm,
+            validator: (value) =>
+                Validators.confirmPassword(value, _passwordController.text),
+            suffixIcon: IconButton(
+              icon: Icon(
+                _obscureConfirm ? LucideIcons.eyeOff : LucideIcons.eye,
+                size: 20,
+              ),
+              onPressed: () =>
+                  setState(() => _obscureConfirm = !_obscureConfirm),
+            ),
           ),
           const SizedBox(height: 32),
           AppButton(
-            text: 'Envoyer le lien',
+            text: 'Réinitialiser',
             fullWidth: true,
             size: AppButtonSize.lg,
             isLoading: _isLoading,
@@ -126,22 +166,23 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
           width: 80,
           height: 80,
           decoration: BoxDecoration(
-            color: Theme.of(context).brightness == Brightness.dark
-                ? Colors.white.withValues(alpha: 0.1)
-                : AppColors.neutral100,
+            color: AppColors.success.withValues(alpha: 0.15),
             borderRadius: BorderRadius.circular(40),
           ),
-          child: Icon(
-            LucideIcons.mailCheck,
+          child: const Icon(
+            LucideIcons.checkCircle,
             size: 36,
-            color: Theme.of(context).colorScheme.onSurface,
+            color: AppColors.success,
           ),
         ),
         const SizedBox(height: 32),
-        Text('Email envoyé', style: Theme.of(context).textTheme.displaySmall),
+        Text(
+          'Mot de passe modifié',
+          style: Theme.of(context).textTheme.displaySmall,
+        ),
         const SizedBox(height: 16),
         Text(
-          'Si un compte existe avec l\'adresse ${_emailController.text.trim()}, vous recevrez un email avec les instructions pour réinitialiser votre mot de passe.',
+          'Votre mot de passe a été réinitialisé avec succès. Vous pouvez maintenant vous connecter.',
           textAlign: TextAlign.center,
           style: Theme.of(
             context,
@@ -149,17 +190,10 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
         ),
         const SizedBox(height: 48),
         AppButton(
-          text: 'Retour à la connexion',
+          text: 'Se connecter',
           fullWidth: true,
           size: AppButtonSize.lg,
-          onPressed: () => context.pop(),
-        ),
-        const SizedBox(height: 12),
-        AppButton(
-          text: 'J\'ai reçu le code',
-          variant: AppButtonVariant.outline,
-          fullWidth: true,
-          onPressed: () => context.push(AppRoutes.resetPassword),
+          onPressed: () => context.go(AppRoutes.login),
         ),
         const SizedBox(height: 48),
       ],


### PR DESCRIPTION
- Add forgotPassword and resetPassword endpoints in ApiClient
- Add service and provider methods with mock mode support
- Create ResetPasswordScreen for token + new password entry
- Show 'arrive bientôt' snackbar on login screen (email not yet implemented)
- Add /reset-password route, ready to activate when backend sends emails

Relates to #46