### PR TITLE
fix: use path_provider instead of /tmp/ for video downloads

### DIFF
--- a/lib/features/export/presentation/providers/export_provider.dart
+++ b/lib/features/export/presentation/providers/export_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:visiobook_mobile/features/export/data/export_service.dart';
 import 'package:visiobook_mobile/features/export/domain/export_state.dart';
@@ -73,8 +74,7 @@ class ExportProvider extends ChangeNotifier {
     _error = null;
     notifyListeners();
 
-    // Build a mock save path (in real app would use path_provider)
-    final savePath = '/tmp/visiobook_$projectId.mp4';
+    final savePath = await _buildSavePath(projectId);
 
     final result = await _exportService.downloadVideo(
       projectId: projectId,
@@ -133,6 +133,19 @@ class ExportProvider extends ChangeNotifier {
     await SharePlus.instance.share(
       ShareParams(text: 'Decouvre mon VisioBook "$title" !\n$link'),
     );
+  }
+
+  /// Construit le chemin de sauvegarde selon la plateforme
+  Future<String> _buildSavePath(String projectId) async {
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final fileName = 'VisioBook_${projectId}_$timestamp.mp4';
+    try {
+      final dir = await getApplicationDocumentsDirectory();
+      return '${dir.path}/$fileName';
+    } catch (_) {
+      // Fallback (tests ou plateforme non supportee)
+      return '/tmp/$fileName';
+    }
   }
 
   /// Reset

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -641,7 +641,7 @@ packages:
     source: hosted
     version: "1.9.1"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ dependencies:
   url_launcher: ^6.2.0
   flutter_local_notifications: ^21.0.0
   http_parser: ^4.1.2
+  path_provider: ^2.1.5
 
 dev_dependencies:
   flutter_test:

--- a/test/unit/export_provider_test.dart
+++ b/test/unit/export_provider_test.dart
@@ -133,7 +133,7 @@ void main() {
       expect(provider.status, ExportStatus.completed);
       expect(provider.isCompleted, isTrue);
       expect(provider.downloadedFilePath, isNotNull);
-      expect(provider.downloadedFilePath, '/tmp/visiobook_project_123.mp4');
+      expect(provider.downloadedFilePath, contains('VisioBook_project_123'));
       expect(provider.downloadProgress, 1.0);
       expect(provider.error, isNull);
     });


### PR DESCRIPTION
- Use getApplicationDocumentsDirectory() for save path
- Filename format: VisioBook_{projectId}_{timestamp}.mp4
- Graceful fallback to /tmp/ if path_provider unavailable
- Add path_provider dependency

Closes #48