### PR TITLE
feat: add retry mechanism for file uploads

### DIFF
--- a/lib/features/import/data/storage_service.dart
+++ b/lib/features/import/data/storage_service.dart
@@ -27,52 +27,54 @@ class StorageService {
     ImportFile importFile, {
     String? projectId,
     Function(double)? onProgress,
-  }) async {
-    try {
-      final file = File(importFile.path);
-      if (!await file.exists()) {
-        return StorageResult(success: false, error: 'Fichier introuvable');
-      }
+  }) {
+    return _withRetry(() async {
+      try {
+        final file = File(importFile.path);
+        if (!await file.exists()) {
+          return StorageResult(success: false, error: 'Fichier introuvable');
+        }
 
-      final contentType = importFile.type.mimeType != null
-          ? MediaType.parse(importFile.type.mimeType!)
-          : null;
+        final contentType = importFile.type.mimeType != null
+            ? MediaType.parse(importFile.type.mimeType!)
+            : null;
 
-      final formData = FormData.fromMap({
-        'file': await MultipartFile.fromFile(
-          importFile.path,
-          filename: importFile.name,
-          contentType: contentType,
-        ),
-        'project_id': projectId ?? '',
-      });
+        final formData = FormData.fromMap({
+          'file': await MultipartFile.fromFile(
+            importFile.path,
+            filename: importFile.name,
+            contentType: contentType,
+          ),
+          'project_id': projectId ?? '',
+        });
 
-      final response = await _apiClient.dio.post(
-        '${EnvironmentConfig.ingestionServiceUrl}/upload/',
-        data: formData,
-        options: Options(contentType: 'multipart/form-data'),
-        onSendProgress: onProgress != null
-            ? (sent, total) {
-                if (total > 0) {
-                  onProgress(sent / total);
+        final response = await _apiClient.dio.post(
+          '${EnvironmentConfig.ingestionServiceUrl}/upload/',
+          data: formData,
+          options: Options(contentType: 'multipart/form-data'),
+          onSendProgress: onProgress != null
+              ? (sent, total) {
+                  if (total > 0) {
+                    onProgress(sent / total);
+                  }
                 }
-              }
-            : null,
-      );
+              : null,
+        );
 
-      final data = response.data;
-      return StorageResult(
-        success: true,
-        data: UploadResult.success(
-          fileId: data['fileId'] as String? ?? '',
-          fileUrl: '',
-        ),
-      );
-    } on DioException catch (e) {
-      return StorageResult(success: false, error: _handleError(e));
-    } catch (e) {
-      return StorageResult(success: false, error: 'Erreur inattendue: $e');
-    }
+        final data = response.data;
+        return StorageResult(
+          success: true,
+          data: UploadResult.success(
+            fileId: data['fileId'] as String? ?? '',
+            fileUrl: '',
+          ),
+        );
+      } on DioException catch (e) {
+        return StorageResult(success: false, error: _handleError(e));
+      } catch (e) {
+        return StorageResult(success: false, error: 'Erreur inattendue: $e');
+      }
+    });
   }
 
   /// Lance l'ingestion asynchrone d'un fichier deja uploade
@@ -130,48 +132,50 @@ class StorageService {
   Future<StorageResult<UploadResult>> extractTextFromFile(
     ImportFile importFile, {
     Function(double)? onProgress,
-  }) async {
-    try {
-      final file = File(importFile.path);
-      if (!await file.exists()) {
-        return StorageResult(success: false, error: 'Fichier introuvable');
-      }
+  }) {
+    return _withRetry(() async {
+      try {
+        final file = File(importFile.path);
+        if (!await file.exists()) {
+          return StorageResult(success: false, error: 'Fichier introuvable');
+        }
 
-      final formData = FormData.fromMap({
-        'file': await MultipartFile.fromFile(
-          importFile.path,
-          filename: importFile.name,
-        ),
-      });
+        final formData = FormData.fromMap({
+          'file': await MultipartFile.fromFile(
+            importFile.path,
+            filename: importFile.name,
+          ),
+        });
 
-      final response = await _apiClient.dio.post(
-        '${EnvironmentConfig.ingestionServiceUrl}/extract/text',
-        data: formData,
-        options: Options(contentType: 'multipart/form-data'),
-        onSendProgress: onProgress != null
-            ? (sent, total) {
-                if (total > 0) {
-                  onProgress(sent / total);
+        final response = await _apiClient.dio.post(
+          '${EnvironmentConfig.ingestionServiceUrl}/extract/text',
+          data: formData,
+          options: Options(contentType: 'multipart/form-data'),
+          onSendProgress: onProgress != null
+              ? (sent, total) {
+                  if (total > 0) {
+                    onProgress(sent / total);
+                  }
                 }
-              }
-            : null,
-      );
+              : null,
+        );
 
-      final data = response.data;
-      return StorageResult(
-        success: true,
-        data: UploadResult.success(
-          fileId: '',
-          fileUrl: '',
-          extractedText: data['text'] as String?,
-          wordCount: data['wordCount'] as int?,
-        ),
-      );
-    } on DioException catch (e) {
-      return StorageResult(success: false, error: _handleError(e));
-    } catch (e) {
-      return StorageResult(success: false, error: 'Erreur inattendue: $e');
-    }
+        final data = response.data;
+        return StorageResult(
+          success: true,
+          data: UploadResult.success(
+            fileId: '',
+            fileUrl: '',
+            extractedText: data['text'] as String?,
+            wordCount: data['wordCount'] as int?,
+          ),
+        );
+      } on DioException catch (e) {
+        return StorageResult(success: false, error: _handleError(e));
+      } catch (e) {
+        return StorageResult(success: false, error: 'Erreur inattendue: $e');
+      }
+    });
   }
 
   /// Recupere la liste des fichiers de l'utilisateur
@@ -200,6 +204,35 @@ class StorageService {
     } catch (e) {
       return StorageResult(success: false, error: 'Erreur inattendue: $e');
     }
+  }
+
+  /// Execute une operation avec retry automatique
+  Future<StorageResult<T>> _withRetry<T>(
+    Future<StorageResult<T>> Function() operation, {
+    int maxAttempts = 3,
+  }) async {
+    StorageResult<T>? lastResult;
+
+    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+      lastResult = await operation();
+
+      if (lastResult.success) return lastResult;
+
+      // Ne pas retry sur les erreurs client (4xx)
+      if (lastResult.error != null &&
+          (lastResult.error!.contains('introuvable') ||
+              lastResult.error!.contains('volumineux') ||
+              lastResult.error!.contains('non supporté'))) {
+        return lastResult;
+      }
+
+      // Attendre avant le prochain essai (sauf le dernier)
+      if (attempt < maxAttempts) {
+        await Future.delayed(Duration(seconds: 1 << (attempt - 1)));
+      }
+    }
+
+    return lastResult!;
   }
 
   String _handleError(DioException e) {

--- a/lib/features/import/presentation/providers/import_provider.dart
+++ b/lib/features/import/presentation/providers/import_provider.dart
@@ -275,7 +275,8 @@ Finalement, le petit prince arriva sur Terre, ou il rencontra un renard qui lui 
         );
 
         if (!uploadResult.success || uploadResult.data == null) {
-          _error = uploadResult.error;
+          _error =
+              uploadResult.error ?? 'Échec de l\'upload de l\'image ${i + 1}';
           _state = ImportState.error;
           notifyListeners();
           return false;
@@ -284,8 +285,15 @@ Finalement, le petit prince arriva sur Terre, ou il rencontra un renard qui lui 
         firstFileId ??= uploadResult.data!.fileId;
       }
 
+      if (firstFileId == null) {
+        _error = 'Aucune image uploadée';
+        _state = ImportState.error;
+        notifyListeners();
+        return false;
+      }
+
       // Lancer l'ingestion (le backend fait l'OCR)
-      if (firstFileId != null && firstFileId.isNotEmpty) {
+      if (firstFileId.isNotEmpty) {
         _uploadProgress = 0.95;
         notifyListeners();
         final ingestionResult = await _storageService.startIngestion(
@@ -306,10 +314,7 @@ Finalement, le petit prince arriva sur Terre, ou il rencontra un renard qui lui 
         selectedAt: DateTime.now(),
       );
 
-      _uploadResult = UploadResult.success(
-        fileId: firstFileId ?? '',
-        fileUrl: '',
-      );
+      _uploadResult = UploadResult.success(fileId: firstFileId, fileUrl: '');
       _uploadProgress = 1.0;
       _state = ImportState.uploaded;
       notifyListeners();

--- a/lib/features/import/presentation/screens/file_import_screen.dart
+++ b/lib/features/import/presentation/screens/file_import_screen.dart
@@ -65,9 +65,34 @@ class FileImportScreen extends StatelessWidget {
                       _FilePickerZone(onTap: () => provider.pickFile()),
 
                     // Erreur
-                    if (provider.error != null) ...[
+                    if (provider.error != null && !provider.isUploading) ...[
                       const SizedBox(height: 16),
                       _ErrorMessage(message: provider.error!),
+                      const SizedBox(height: 12),
+                      AppButton(
+                        text: 'Réessayer',
+                        variant: AppButtonVariant.outline,
+                        fullWidth: true,
+                        icon: const Icon(LucideIcons.refreshCw, size: 18),
+                        onPressed: () async {
+                          provider.clearError();
+                          final success = await provider.uploadFile();
+                          if (success && context.mounted) {
+                            final jobId = provider.lastIngestionJobId;
+                            final fileId = provider.lastIngestionFileId;
+                            if (jobId != null && fileId != null) {
+                              context
+                                  .read<TextsProvider>()
+                                  .startIngestionTracking(
+                                    fileId,
+                                    jobId,
+                                    provider.selectedFile?.name ?? 'Fichier',
+                                  );
+                            }
+                            context.push(AppRoutes.textPreview);
+                          }
+                        },
+                      ),
                     ],
 
                     // Progress bar


### PR DESCRIPTION
- Auto-retry uploads up to 3 times with exponential backoff (1s, 2s, 4s)
- Skip retry on client errors (4xx)
- Add Réessayer button on upload error screen
- Scan stops on first image failure (after retries) to preserve order
- Apply retry to both uploadFile and extractTextFromFile

Closes #50