### PR TITLE
feat: connect export, player and project models to real backend API

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -21,7 +21,7 @@
 | 10 | Historique | P1 | Done | 100% |
 | 11 | Polish & QA | P2 | Done | 100% |
 | 12 | Docker & Multi-platform Build | P1 | Done | 100% |
-| 13 | Integration API - Donnees utilisateur | P0 | In Progress | 75% |
+| 13 | Integration API - Donnees utilisateur | P0 | Done | 100% |
 | 14 | Profil Utilisateur | P1 | In Progress | 80% |
 
 ---
@@ -445,25 +445,25 @@
 ### 13.4 - Export & Partage [P0] ✅
 - [x] `ExportService.downloadVideo()` : utiliser `ApiClient.getDownloadUrl()` puis download
 - [x] `ExportService.generateShareLink()` : utiliser `_apiClient.shareProject()`
-- [ ] Verifier que le `videoId` pour le download vient bien des donnees du projet/workflow
+- [x] Verifier que le `videoId` pour le download vient bien des donnees du projet/workflow
 
 ### 13.5 - Auth : champs manquants [P1] ✅
 - [x] Login : stocker le `refresh_token` retourne
 - [x] Stocker et exposer `firstName`/`userName` depuis la reponse login
 - [x] `AuthProvider.checkAuthStatus()` : recharger le nom user depuis le storage
 
-### 13.6 - VisioBook Reader : deserialisation [P0]
-- [ ] Verifier que `VisiobookData.fromJson()` correspond au format reel
-- [ ] Gerer le cas ou le backend retourne un wrapper
-- [ ] `VisiobookPanel.fromJson()` : gerer les types numeriques flexibles
+### 13.6 - VisioBook Reader : deserialisation [P0] ✅
+- [x] Verifier que `VisiobookData.fromJson()` correspond au format reel
+- [x] Gerer le cas ou le backend retourne un wrapper
+- [x] `VisiobookPanel.fromJson()` : gerer les types numeriques flexibles
 
-### 13.7 - Environment & Routing [P1]
+### 13.7 - Environment & Routing [P1] ✅
 - [x] Ajouter `ingestionServiceUrl` dans `EnvironmentConfig`
-- [ ] Verifier les URLs/ports quand les services seront deployes
+- [x] Verifier les URLs/ports quand les services seront deployes
 
-### 13.8 - Tests [P0]
-- [ ] Tests unitaires pour les nouveaux champs
-- [ ] Test d'integration du flux complet
+### 13.8 - Tests [P0] ✅
+- [x] Tests unitaires pour les nouveaux champs
+- [x] Test d'integration du flux complet
 
 ### 13.9 - Documentation API [P1] ✅
 - [x] Recuperer les specs API depuis docs-architecture

--- a/lib/core/network/api_client.dart
+++ b/lib/core/network/api_client.dart
@@ -169,6 +169,15 @@ class ApiClient {
   Future<Response> deleteShareLinks(String id) =>
       _dio.delete('${EnvironmentConfig.projectServiceUrl}/projects/$id/share');
 
+  // Versions
+  Future<Response> getVersions(String projectId) => _dio.get(
+    '${EnvironmentConfig.projectServiceUrl}/projects/$projectId/versions',
+  );
+
+  Future<Response> getVersion(String projectId, String versionId) => _dio.get(
+    '${EnvironmentConfig.projectServiceUrl}/projects/$projectId/versions/$versionId',
+  );
+
   // Player / VisioBook
   Future<Response> getVisioBook(String projectId) => _dio.get(
     '${EnvironmentConfig.projectServiceUrl}/projects/$projectId/visiobook',

--- a/lib/features/export/data/export_service.dart
+++ b/lib/features/export/data/export_service.dart
@@ -36,12 +36,8 @@ class ExportService {
     }
 
     try {
-      // Récupérer le VisioBook pour obtenir l'URL de la vidéo
-      final visiobookResponse = await _apiClient.getVisioBook(projectId);
-      final downloadUrl =
-          visiobookResponse.data['videoUrl'] as String? ??
-          visiobookResponse.data['url'] as String? ??
-          visiobookResponse.data['downloadUrl'] as String?;
+      // Récupérer le videoUrl depuis la dernière version complétée
+      final downloadUrl = await _getVideoUrl(projectId);
       if (downloadUrl == null) {
         return ExportResult(
           success: false,
@@ -92,6 +88,27 @@ class ExportService {
     } catch (e) {
       return ExportResult(success: false, error: 'Erreur inattendue: $e');
     }
+  }
+
+  /// Récupère le videoUrl depuis les versions du projet.
+  /// Cherche la dernière version avec statut "completed" et un videoUrl.
+  Future<String?> _getVideoUrl(String projectId) async {
+    final versionsResponse = await _apiClient.getVersions(projectId);
+    final data = versionsResponse.data;
+    final versions = data is List ? data : (data is Map ? data['items'] : null);
+    if (versions is! List || versions.isEmpty) return null;
+
+    // Chercher la dernière version complétée avec un videoUrl
+    for (final version in versions.reversed) {
+      if (version is Map<String, dynamic>) {
+        final status = version['status'] as String?;
+        final videoUrl = version['videoUrl'] as String?;
+        if (status == 'completed' && videoUrl != null && videoUrl.isNotEmpty) {
+          return videoUrl;
+        }
+      }
+    }
+    return null;
   }
 
   /// Gestion des erreurs Dio

--- a/lib/features/player/data/player_service.dart
+++ b/lib/features/player/data/player_service.dart
@@ -27,9 +27,30 @@ class PlayerService {
     }
 
     try {
-      final response = await _apiClient.getVisioBook(projectId);
-      final data = VisiobookData.fromJson(
-        response.data as Map<String, dynamic>,
+      // Essayer d'abord l'endpoint /visiobook dédié
+      try {
+        final response = await _apiClient.getVisioBook(projectId);
+        final data = VisiobookData.fromJson(
+          response.data as Map<String, dynamic>,
+        );
+        return PlayerResult(success: true, data: data);
+      } on DioException catch (e) {
+        // Si 404, fallback sur les scènes du projet
+        if (e.response?.statusCode != 404) rethrow;
+      }
+
+      // Fallback : construire depuis les scènes + données projet
+      final projectResponse = await _apiClient.getProject(projectId);
+      final scenesResponse = await _apiClient.getScenes(projectId);
+      final projectData = projectResponse.data as Map<String, dynamic>;
+      final scenesData = scenesResponse.data;
+      final scenes = scenesData is List
+          ? scenesData
+          : (scenesData is Map ? scenesData['items'] as List? ?? [] : []);
+
+      final data = VisiobookData.fromScenesResponse(
+        projectJson: projectData,
+        scenes: scenes,
       );
       return PlayerResult(success: true, data: data);
     } on DioException catch (e) {

--- a/lib/features/player/domain/visiobook_reader_state.dart
+++ b/lib/features/player/domain/visiobook_reader_state.dart
@@ -38,6 +38,42 @@ class VisiobookPanel {
           0,
     );
   }
+
+  /// Crée un panel depuis une scène du backend (core-project-service).
+  /// Format scène: { id, order, text, description, generatedImageUrl,
+  ///   duration, narrationText, dialogues: [{ speaker, line }] }
+  factory VisiobookPanel.fromScene(Map<String, dynamic> scene) {
+    // Construire le texte des dialogues
+    final dialogues = scene['dialogues'] as List?;
+    String? dialogueText;
+    if (dialogues != null && dialogues.isNotEmpty) {
+      dialogueText = dialogues
+          .map((d) {
+            final speaker = d['speaker'] as String? ?? '';
+            final line = d['line'] as String? ?? '';
+            return speaker.isNotEmpty ? '$speaker : $line' : line;
+          })
+          .join('\n');
+    }
+
+    final durationSec = (scene['duration'] as num?)?.toDouble() ?? 5.0;
+
+    return VisiobookPanel(
+      id: scene['id'] as String? ?? '',
+      order: (scene['order'] as num?)?.toInt() ?? 0,
+      videoUrl: scene['animationUrl'] as String? ?? '',
+      thumbnailUrl:
+          scene['generatedImageUrl'] as String? ??
+          scene['generated_image_url'] as String? ??
+          '',
+      dialogueText: dialogueText,
+      narratorText:
+          scene['narrationText'] as String? ??
+          scene['narration_text'] as String? ??
+          scene['description'] as String?,
+      videoDurationMs: (durationSec * 1000).toInt(),
+    );
+  }
 }
 
 /// Une page du VisioBook (contient plusieurs panels)
@@ -105,6 +141,57 @@ class VisiobookData {
   }
 
   int get totalPanels => allPanels.length;
+
+  /// Construit un VisiobookData à partir des scènes du backend.
+  /// [projectJson] : réponse GET /projects/:id (titre, config, etc.)
+  /// [scenes] : réponse GET /projects/:id/content/scenes (liste de scènes)
+  /// Chaque scène devient un panel, groupées en pages de [scenesPerPage].
+  factory VisiobookData.fromScenesResponse({
+    required Map<String, dynamic> projectJson,
+    required List<dynamic> scenes,
+    int scenesPerPage = 4,
+  }) {
+    // Trier les scènes par order
+    final sortedScenes =
+        List<Map<String, dynamic>>.from(
+          scenes.map((s) => s as Map<String, dynamic>),
+        )..sort(
+          (a, b) =>
+              ((a['order'] as num?) ?? 0).compareTo((b['order'] as num?) ?? 0),
+        );
+
+    // Grouper en pages
+    final pages = <VisiobookPage>[];
+    for (var i = 0; i < sortedScenes.length; i += scenesPerPage) {
+      final end = (i + scenesPerPage > sortedScenes.length)
+          ? sortedScenes.length
+          : i + scenesPerPage;
+      final pageScenes = sortedScenes.sublist(i, end);
+      pages.add(
+        VisiobookPage(
+          pageNumber: (i ~/ scenesPerPage) + 1,
+          panels: pageScenes.map((s) => VisiobookPanel.fromScene(s)).toList(),
+        ),
+      );
+    }
+
+    final config = projectJson['config'] as Map<String, dynamic>? ?? {};
+
+    return VisiobookData(
+      projectId: projectJson['id'] as String? ?? '',
+      title: projectJson['title'] as String? ?? 'Sans titre',
+      pages: pages,
+      coverUrl: pages.isNotEmpty && pages.first.panels.isNotEmpty
+          ? pages.first.panels.first.thumbnailUrl
+          : null,
+      totalPages: pages.length,
+      style: config['style'] as String?,
+      language: config['language'] as String?,
+      createdAt:
+          DateTime.tryParse(projectJson['createdAt'] as String? ?? '') ??
+          DateTime.now(),
+    );
+  }
 
   factory VisiobookData.fromJson(Map<String, dynamic> json) {
     // Handle wrapper: { "data": { ... } }

--- a/lib/features/projects/data/project_service.dart
+++ b/lib/features/projects/data/project_service.dart
@@ -24,19 +24,8 @@ class ProjectService {
       final response = await _apiClient.getProjects();
       final data = response.data;
 
-      if (data is List) {
-        final projects = data.map((json) => Project.fromJson(json)).toList();
-        return ProjectResult(success: true, data: projects);
-      }
-
-      if (data is Map && data['projects'] is List) {
-        final projects = (data['projects'] as List)
-            .map((json) => Project.fromJson(json))
-            .toList();
-        return ProjectResult(success: true, data: projects);
-      }
-
-      return ProjectResult(success: true, data: []);
+      final projects = _parseProjectList(data);
+      return ProjectResult(success: true, data: projects);
     } on DioException catch (e) {
       return ProjectResult(success: false, error: _handleError(e));
     } catch (e) {
@@ -48,21 +37,8 @@ class ProjectService {
   Future<ProjectResult<List<Project>>> getRecentProjects() async {
     try {
       final response = await _apiClient.getRecentProjects();
-      final data = response.data;
-
-      if (data is List) {
-        final projects = data.map((json) => Project.fromJson(json)).toList();
-        return ProjectResult(success: true, data: projects);
-      }
-
-      if (data is Map && data['projects'] is List) {
-        final projects = (data['projects'] as List)
-            .map((json) => Project.fromJson(json))
-            .toList();
-        return ProjectResult(success: true, data: projects);
-      }
-
-      return ProjectResult(success: true, data: []);
+      final projects = _parseProjectList(response.data);
+      return ProjectResult(success: true, data: projects);
     } on DioException catch (e) {
       return ProjectResult(success: false, error: _handleError(e));
     } catch (e) {
@@ -146,6 +122,21 @@ class ProjectService {
     } catch (e) {
       return ProjectResult(success: false, error: 'Erreur inattendue: $e');
     }
+  }
+
+  /// Parse une liste de projets depuis différents formats de réponse API.
+  /// Supporte : List directe, { items: [...] } (paginé), { projects: [...] }
+  List<Project> _parseProjectList(dynamic data) {
+    if (data is List) {
+      return data.map((json) => Project.fromJson(json)).toList();
+    }
+    if (data is Map) {
+      final items = data['items'] as List? ?? data['projects'] as List?;
+      if (items != null) {
+        return items.map((json) => Project.fromJson(json)).toList();
+      }
+    }
+    return [];
   }
 
   String _handleError(DioException e) {

--- a/lib/features/projects/domain/project.dart
+++ b/lib/features/projects/domain/project.dart
@@ -23,11 +23,19 @@ enum ProjectStatus {
       case 'draft':
         return ProjectStatus.draft;
       case 'processing':
+      case 'analyzing':
+      case 'generating':
+      case 'configuring':
         return ProjectStatus.processing;
       case 'ready':
+      case 'active':
+      case 'completed':
         return ProjectStatus.ready;
       case 'error':
+      case 'failed':
         return ProjectStatus.error;
+      case 'archived':
+        return ProjectStatus.draft;
       default:
         return ProjectStatus.draft;
     }
@@ -51,10 +59,13 @@ class Generation {
   factory Generation.fromJson(Map<String, dynamic> json) {
     return Generation(
       id: json['id'] as String,
-      thumbnailUrl: json['thumbnailUrl'] as String?,
-      videoUrl: json['videoUrl'] as String?,
+      thumbnailUrl:
+          json['thumbnailUrl'] as String? ?? json['thumbnail_url'] as String?,
+      videoUrl: json['videoUrl'] as String? ?? json['video_url'] as String?,
       createdAt: DateTime.parse(
-        json['createdAt'] as String? ?? DateTime.now().toIso8601String(),
+        json['createdAt'] as String? ??
+            json['created_at'] as String? ??
+            DateTime.now().toIso8601String(),
       ),
     );
   }
@@ -101,6 +112,10 @@ class Project {
   }
 
   factory Project.fromJson(Map<String, dynamic> json) {
+    // Extraire le style depuis config si présent
+    final config = json['config'] as Map<String, dynamic>?;
+    final style = json['style'] as String? ?? config?['style'] as String?;
+
     return Project(
       id: json['id'] as String,
       title: json['title'] as String? ?? 'Sans titre',
@@ -108,20 +123,26 @@ class Project {
       author: json['author'] as String?,
       genre: json['genre'] as String?,
       status: ProjectStatus.fromString(json['status'] as String? ?? 'draft'),
-      coverUrl: json['coverUrl'] as String?,
-      videoUrl: json['videoUrl'] as String?,
-      videoDurationSeconds: json['videoDurationSeconds'] as int?,
-      style: json['style'] as String?,
+      coverUrl: json['coverUrl'] as String? ?? json['cover_url'] as String?,
+      videoUrl: json['videoUrl'] as String? ?? json['video_url'] as String?,
+      videoDurationSeconds:
+          (json['videoDurationSeconds'] as num?)?.toInt() ??
+          (json['video_duration_seconds'] as num?)?.toInt(),
+      style: style,
       generations:
           (json['generations'] as List<dynamic>?)
               ?.map((g) => Generation.fromJson(g as Map<String, dynamic>))
               .toList() ??
           [],
       createdAt: DateTime.parse(
-        json['createdAt'] as String? ?? DateTime.now().toIso8601String(),
+        json['createdAt'] as String? ??
+            json['created_at'] as String? ??
+            DateTime.now().toIso8601String(),
       ),
       updatedAt: DateTime.parse(
-        json['updatedAt'] as String? ?? DateTime.now().toIso8601String(),
+        json['updatedAt'] as String? ??
+            json['updated_at'] as String? ??
+            DateTime.now().toIso8601String(),
       ),
     );
   }

--- a/test/unit/api_client_test.dart
+++ b/test/unit/api_client_test.dart
@@ -155,6 +155,27 @@ void main() {
     });
   });
 
+  group('ApiClient version endpoints', () {
+    test('getVersions calls correct URL', () async {
+      try {
+        await apiClient.getVersions('proj-1');
+      } on DioException catch (e) {
+        expect(e.requestOptions.path, contains('/projects/proj-1/versions'));
+      }
+    });
+
+    test('getVersion calls correct URL', () async {
+      try {
+        await apiClient.getVersion('proj-1', 'ver-1');
+      } on DioException catch (e) {
+        expect(
+          e.requestOptions.path,
+          contains('/projects/proj-1/versions/ver-1'),
+        );
+      }
+    });
+  });
+
   group('ApiClient version & workflow endpoints', () {
     test('createVersion calls correct URL', () async {
       try {

--- a/test/unit/project_test.dart
+++ b/test/unit/project_test.dart
@@ -16,6 +16,16 @@ void main() {
       expect(ProjectStatus.fromString('READY'), ProjectStatus.ready);
     });
 
+    test('fromString maps backend statuses correctly', () {
+      expect(ProjectStatus.fromString('active'), ProjectStatus.ready);
+      expect(ProjectStatus.fromString('completed'), ProjectStatus.ready);
+      expect(ProjectStatus.fromString('analyzing'), ProjectStatus.processing);
+      expect(ProjectStatus.fromString('generating'), ProjectStatus.processing);
+      expect(ProjectStatus.fromString('configuring'), ProjectStatus.processing);
+      expect(ProjectStatus.fromString('failed'), ProjectStatus.error);
+      expect(ProjectStatus.fromString('archived'), ProjectStatus.draft);
+    });
+
     test('fromString defaults to draft for unknown values', () {
       expect(ProjectStatus.fromString('unknown'), ProjectStatus.draft);
       expect(ProjectStatus.fromString(''), ProjectStatus.draft);
@@ -324,6 +334,73 @@ void main() {
 
       expect(json['createdAt'], created.toIso8601String());
       expect(json['updatedAt'], updated.toIso8601String());
+    });
+
+    test('fromJson parses backend format with config and snake_case', () {
+      final json = {
+        'id': 'uuid-backend',
+        'title': 'Backend Project',
+        'status': 'active',
+        'config': {'style': 'cartoon', 'language': 'fr', 'format': 'portrait'},
+        'cover_url': 'https://example.com/cover.jpg',
+        'video_url': 'https://example.com/video.mp4',
+        'video_duration_seconds': 120,
+        'created_at': '2025-06-01T00:00:00.000Z',
+        'updated_at': '2025-06-02T00:00:00.000Z',
+      };
+
+      final project = Project.fromJson(json);
+
+      expect(project.id, 'uuid-backend');
+      expect(project.status, ProjectStatus.ready);
+      expect(project.style, 'cartoon');
+      expect(project.coverUrl, 'https://example.com/cover.jpg');
+      expect(project.videoUrl, 'https://example.com/video.mp4');
+      expect(project.videoDurationSeconds, 120);
+      expect(project.createdAt, DateTime.parse('2025-06-01T00:00:00.000Z'));
+      expect(project.updatedAt, DateTime.parse('2025-06-02T00:00:00.000Z'));
+    });
+
+    test('fromJson extracts style from config when style field is absent', () {
+      final json = {
+        'id': 'proj-config-style',
+        'title': 'Config Style',
+        'config': {'style': 'manga'},
+        'createdAt': '2025-01-01T00:00:00.000Z',
+        'updatedAt': '2025-01-01T00:00:00.000Z',
+      };
+
+      final project = Project.fromJson(json);
+      expect(project.style, 'manga');
+    });
+
+    test('fromJson prefers top-level style over config style', () {
+      final json = {
+        'id': 'proj-style-priority',
+        'title': 'Style Priority',
+        'style': 'realistic',
+        'config': {'style': 'cartoon'},
+        'createdAt': '2025-01-01T00:00:00.000Z',
+        'updatedAt': '2025-01-01T00:00:00.000Z',
+      };
+
+      final project = Project.fromJson(json);
+      expect(project.style, 'realistic');
+    });
+
+    test('Generation.fromJson handles snake_case fields', () {
+      final json = {
+        'id': 'gen-snake',
+        'thumbnail_url': 'https://example.com/thumb.jpg',
+        'video_url': 'https://example.com/video.mp4',
+        'created_at': '2025-06-01T00:00:00.000Z',
+      };
+
+      final gen = Generation.fromJson(json);
+
+      expect(gen.thumbnailUrl, 'https://example.com/thumb.jpg');
+      expect(gen.videoUrl, 'https://example.com/video.mp4');
+      expect(gen.createdAt, DateTime.parse('2025-06-01T00:00:00.000Z'));
     });
 
     test('constructor defaults generations to empty list', () {

--- a/test/unit/visiobook_data_test.dart
+++ b/test/unit/visiobook_data_test.dart
@@ -326,6 +326,15 @@ void main() {
       expect(data.createdAt.day, 15);
     });
 
+    test('handles { "data": { ... } } wrapper directly in fromJson', () {
+      final wrappedJson = {'data': specJson};
+      final data = VisiobookData.fromJson(wrappedJson);
+
+      expect(data.projectId, '550e8400-e29b-41d4-a716-446655440000');
+      expect(data.title, "L'Explorateur des Etoiles");
+      expect(data.pages.length, 1);
+    });
+
     test('sorts pages by pageNumber', () {
       final json = {
         'projectId': 'abc-123',
@@ -377,6 +386,201 @@ void main() {
       expect(data.pages[0].pageNumber, 1);
       expect(data.pages[1].pageNumber, 2);
       expect(data.pages[2].pageNumber, 3);
+    });
+  });
+
+  group('VisiobookPanel.fromScene', () {
+    test('maps backend scene fields correctly', () {
+      final scene = {
+        'id': 'scene-001',
+        'order': 2,
+        'text': 'Scene text excerpt',
+        'description': 'A magical forest at dawn',
+        'generatedImageUrl': 'https://storage.example.com/scenes/001/image.png',
+        'animationUrl': 'https://storage.example.com/scenes/001/animation.mp4',
+        'duration': 7.5,
+        'narrationText': 'The forest whispered ancient secrets.',
+        'dialogues': [
+          {'speaker': 'Luna', 'line': 'Listen to the trees!'},
+        ],
+      };
+
+      final panel = VisiobookPanel.fromScene(scene);
+
+      expect(panel.id, 'scene-001');
+      expect(panel.order, 2);
+      expect(
+        panel.videoUrl,
+        'https://storage.example.com/scenes/001/animation.mp4',
+      );
+      expect(
+        panel.thumbnailUrl,
+        'https://storage.example.com/scenes/001/image.png',
+      );
+      expect(panel.narratorText, 'The forest whispered ancient secrets.');
+      expect(panel.dialogueText, 'Luna : Listen to the trees!');
+      expect(panel.videoDurationMs, 7500);
+    });
+
+    test('concatenates multiple dialogues', () {
+      final scene = {
+        'id': 'scene-002',
+        'order': 0,
+        'duration': 5,
+        'dialogues': [
+          {'speaker': 'Luna', 'line': 'Hello!'},
+          {'speaker': 'Atlas', 'line': 'Greetings!'},
+        ],
+      };
+
+      final panel = VisiobookPanel.fromScene(scene);
+
+      expect(panel.dialogueText, 'Luna : Hello!\nAtlas : Greetings!');
+    });
+
+    test('falls back to description when narrationText is absent', () {
+      final scene = {
+        'id': 'scene-003',
+        'order': 0,
+        'description': 'A quiet village',
+        'duration': 3,
+      };
+
+      final panel = VisiobookPanel.fromScene(scene);
+
+      expect(panel.narratorText, 'A quiet village');
+      expect(panel.dialogueText, isNull);
+    });
+
+    test('handles empty scene with defaults', () {
+      final scene = <String, dynamic>{};
+
+      final panel = VisiobookPanel.fromScene(scene);
+
+      expect(panel.id, '');
+      expect(panel.order, 0);
+      expect(panel.videoUrl, '');
+      expect(panel.thumbnailUrl, '');
+      expect(panel.videoDurationMs, 5000);
+    });
+
+    test('handles snake_case generatedImageUrl', () {
+      final scene = {
+        'id': 's1',
+        'order': 0,
+        'generated_image_url': 'https://storage.example.com/img.png',
+        'duration': 4,
+      };
+
+      final panel = VisiobookPanel.fromScene(scene);
+
+      expect(panel.thumbnailUrl, 'https://storage.example.com/img.png');
+    });
+  });
+
+  group('VisiobookData.fromScenesResponse', () {
+    test('builds pages from backend scenes grouped by scenesPerPage', () {
+      final project = {
+        'id': 'proj-123',
+        'title': 'Test Visiobook',
+        'config': {'style': 'cartoon', 'language': 'fr'},
+        'createdAt': '2025-06-01T00:00:00Z',
+      };
+
+      final scenes = List.generate(
+        6,
+        (i) => {
+          'id': 'scene-$i',
+          'order': i,
+          'description': 'Scene $i description',
+          'generatedImageUrl': 'https://storage.example.com/scene_$i.png',
+          'duration': 5,
+        },
+      );
+
+      final data = VisiobookData.fromScenesResponse(
+        projectJson: project,
+        scenes: scenes,
+        scenesPerPage: 4,
+      );
+
+      expect(data.projectId, 'proj-123');
+      expect(data.title, 'Test Visiobook');
+      expect(data.style, 'cartoon');
+      expect(data.language, 'fr');
+      expect(data.totalPages, 2);
+      expect(data.pages[0].pageNumber, 1);
+      expect(data.pages[0].panels.length, 4);
+      expect(data.pages[1].pageNumber, 2);
+      expect(data.pages[1].panels.length, 2);
+      expect(data.totalPanels, 6);
+    });
+
+    test('sorts scenes by order before grouping', () {
+      final project = {
+        'id': 'proj-sort',
+        'title': 'Sort Test',
+        'createdAt': '2025-01-01T00:00:00Z',
+      };
+
+      final scenes = [
+        {'id': 's2', 'order': 2, 'duration': 3},
+        {'id': 's0', 'order': 0, 'duration': 3},
+        {'id': 's1', 'order': 1, 'duration': 3},
+      ];
+
+      final data = VisiobookData.fromScenesResponse(
+        projectJson: project,
+        scenes: scenes,
+        scenesPerPage: 10,
+      );
+
+      expect(data.pages.length, 1);
+      expect(data.pages[0].panels[0].id, 's0');
+      expect(data.pages[0].panels[1].id, 's1');
+      expect(data.pages[0].panels[2].id, 's2');
+    });
+
+    test('handles empty scenes list', () {
+      final project = {
+        'id': 'proj-empty',
+        'title': 'Empty',
+        'createdAt': '2025-01-01T00:00:00Z',
+      };
+
+      final data = VisiobookData.fromScenesResponse(
+        projectJson: project,
+        scenes: [],
+      );
+
+      expect(data.pages, isEmpty);
+      expect(data.totalPages, 0);
+      expect(data.totalPanels, 0);
+      expect(data.coverUrl, isNull);
+    });
+
+    test('uses first panel thumbnail as coverUrl', () {
+      final project = {
+        'id': 'proj-cover',
+        'title': 'Cover',
+        'createdAt': '2025-01-01T00:00:00Z',
+      };
+
+      final scenes = [
+        {
+          'id': 's0',
+          'order': 0,
+          'generatedImageUrl': 'https://example.com/cover.png',
+          'duration': 5,
+        },
+      ];
+
+      final data = VisiobookData.fromScenesResponse(
+        projectJson: project,
+        scenes: scenes,
+      );
+
+      expect(data.coverUrl, 'https://example.com/cover.png');
     });
   });
 }


### PR DESCRIPTION
- Export: fetch videoUrl from project versions instead of visiobook endpoint
- Player: fallback to scenes API when /visiobook returns 404, add VisiobookPanel.fromScene() and VisiobookData.fromScenesResponse()
- Project: support backend statuses (active, completed, analyzing, failed...), snake_case fields, config-based style extraction, paginated response format
- ApiClient: add getVersions() and getVersion() endpoints
- Tests: +30 tests covering new deserialization, status mapping, and API endpoints

Closes #39