### PR TITLE
fix: apply glassmorphism to light mode (semi-transparent cards, input…

### DIFF
--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -38,6 +38,10 @@ class AppTheme {
   static const double radiusLg = 24.0;
   static const double radiusXl = 28.0;
 
+  // Glass colors for light mode (semi-transparent white)
+  static const Color _lightGlass = Color(0xB3FFFFFF); // white 70%
+  static const Color _lightGlassBorder = Color(0x26000000); // black 15%
+
   static ThemeData get lightTheme {
     return ThemeData(
       useMaterial3: true,
@@ -48,39 +52,43 @@ class AppTheme {
         onPrimary: Colors.white,
         secondary: AppColors.neutral100,
         onSecondary: AppColors.neutral900,
-        surface: Colors.white,
+        surface: Color(0xB3FFFFFF),
         onSurface: AppColors.neutral900,
         error: AppColors.error,
         onError: Colors.white,
         outline: AppColors.neutral200,
       ),
       appBarTheme: const AppBarTheme(
-        backgroundColor: Colors.white,
+        backgroundColor: Colors.transparent,
         foregroundColor: AppColors.neutral900,
         elevation: 0,
       ),
       cardTheme: CardThemeData(
-        color: Colors.white,
+        color: _lightGlass,
         elevation: 0,
         shadowColor: AppColors.glassShadow,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(radiusMd),
+          side: const BorderSide(color: _lightGlassBorder, width: 0.5),
         ),
       ),
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
-        fillColor: Colors.white,
+        fillColor: _lightGlass,
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(radiusMd),
-          borderSide: const BorderSide(color: AppColors.neutral200),
+          borderSide: const BorderSide(color: _lightGlassBorder),
         ),
         enabledBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(radiusMd),
-          borderSide: const BorderSide(color: AppColors.neutral200),
+          borderSide: const BorderSide(color: _lightGlassBorder),
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(radiusMd),
-          borderSide: const BorderSide(color: AppColors.neutral900, width: 2),
+          borderSide: BorderSide(
+            color: AppColors.neutral900.withValues(alpha: 0.4),
+            width: 2,
+          ),
         ),
         contentPadding: const EdgeInsets.symmetric(
           horizontal: 16,

--- a/lib/core/widgets/app_button.dart
+++ b/lib/core/widgets/app_button.dart
@@ -54,10 +54,12 @@ class _AppButtonState extends State<AppButton> {
         border = Border.all(color: Colors.white.withValues(alpha: 0.25));
       } else {
         backgroundColor = _isPressed
-            ? AppColors.neutral900.withValues(alpha: 0.85)
-            : AppColors.neutral900;
-        textColor = Colors.white;
-        border = null;
+            ? AppColors.neutral900.withValues(alpha: 0.12)
+            : AppColors.neutral900.withValues(alpha: 0.08);
+        textColor = AppColors.neutral900;
+        border = Border.all(
+          color: AppColors.neutral900.withValues(alpha: 0.15),
+        );
       }
     } else {
       if (isDark) {
@@ -68,10 +70,12 @@ class _AppButtonState extends State<AppButton> {
         border = Border.all(color: Colors.white.withValues(alpha: 0.2));
       } else {
         backgroundColor = _isPressed
-            ? AppColors.neutral900.withValues(alpha: 0.05)
-            : Colors.transparent;
+            ? AppColors.neutral900.withValues(alpha: 0.06)
+            : AppColors.neutral900.withValues(alpha: 0.03);
         textColor = AppColors.neutral900;
-        border = Border.all(color: AppColors.neutral900, width: 2);
+        border = Border.all(
+          color: AppColors.neutral900.withValues(alpha: 0.12),
+        );
       }
     }
 

--- a/lib/features/auth/presentation/screens/forgot_password_screen.dart
+++ b/lib/features/auth/presentation/screens/forgot_password_screen.dart
@@ -128,7 +128,7 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
           decoration: BoxDecoration(
             color: Theme.of(context).brightness == Brightness.dark
                 ? Colors.white.withValues(alpha: 0.1)
-                : AppColors.neutral100,
+                : Colors.white.withValues(alpha: 0.7),
             borderRadius: BorderRadius.circular(40),
           ),
           child: Icon(

--- a/lib/features/auth/presentation/screens/onboarding_screen.dart
+++ b/lib/features/auth/presentation/screens/onboarding_screen.dart
@@ -172,7 +172,7 @@ class _SlideWidget extends StatelessWidget {
             decoration: BoxDecoration(
               color: isDark
                   ? Colors.white.withValues(alpha: 0.1)
-                  : AppColors.neutral100,
+                  : Colors.white.withValues(alpha: 0.7),
               borderRadius: BorderRadius.circular(50),
             ),
             child: Icon(

--- a/lib/features/export/presentation/widgets/export_share_sheet.dart
+++ b/lib/features/export/presentation/widgets/export_share_sheet.dart
@@ -236,7 +236,7 @@ class _ExportShareSheetState extends State<ExportShareSheet> {
       selected: isSelected,
       onSelected: (_) => provider.setQuality(quality),
       selectedColor: AppColors.neutral900,
-      backgroundColor: AppColors.neutral100,
+      backgroundColor: Colors.white.withValues(alpha: 0.7),
       labelStyle: TextStyle(
         fontSize: 13,
         fontWeight: FontWeight.w500,

--- a/lib/features/history/presentation/screens/text_detail_screen.dart
+++ b/lib/features/history/presentation/screens/text_detail_screen.dart
@@ -140,12 +140,19 @@ class _TextDetailScreenState extends State<TextDetailScreen> {
                           decoration: BoxDecoration(
                             color: isDark
                                 ? Colors.white.withValues(alpha: 0.15)
-                                : AppColors.neutral900,
+                                : AppColors.neutral900.withValues(alpha: 0.08),
                             borderRadius: BorderRadius.circular(10),
+                            border: isDark
+                                ? null
+                                : Border.all(
+                                    color: AppColors.neutral900.withValues(
+                                      alpha: 0.12,
+                                    ),
+                                  ),
                           ),
-                          child: const Icon(
+                          child: Icon(
                             LucideIcons.fileText,
-                            color: Colors.white,
+                            color: isDark ? Colors.white : AppColors.neutral900,
                             size: 20,
                           ),
                         ),

--- a/lib/features/history/presentation/screens/texts_history_screen.dart
+++ b/lib/features/history/presentation/screens/texts_history_screen.dart
@@ -123,7 +123,7 @@ class _TextsHistoryScreenState extends State<TextsHistoryScreen> {
                       filled: true,
                       fillColor: isDark
                           ? Colors.white.withValues(alpha: 0.08)
-                          : AppColors.neutral100,
+                          : Colors.white.withValues(alpha: 0.7),
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(AppTheme.radiusMd),
                         borderSide: BorderSide.none,
@@ -229,10 +229,13 @@ class _TextsHistoryScreenState extends State<TextsHistoryScreen> {
           color: isSelected
               ? (isDark
                     ? Colors.white.withValues(alpha: 0.15)
-                    : AppColors.neutral900)
+                    : AppColors.neutral900.withValues(alpha: 0.08))
               : (isDark
                     ? Colors.white.withValues(alpha: 0.08)
                     : AppColors.neutral100),
+          border: isSelected && !isDark
+              ? Border.all(color: AppColors.neutral900.withValues(alpha: 0.15))
+              : null,
           borderRadius: BorderRadius.circular(AppTheme.radiusSm),
         ),
         child: Text(
@@ -241,7 +244,7 @@ class _TextsHistoryScreenState extends State<TextsHistoryScreen> {
             fontSize: 14,
             fontWeight: FontWeight.w500,
             color: isSelected
-                ? Colors.white
+                ? (isDark ? Colors.white : AppColors.neutral900)
                 : (isDark ? AppColors.neutral300 : AppColors.neutral600),
           ),
         ),
@@ -269,7 +272,7 @@ class _TextsHistoryScreenState extends State<TextsHistoryScreen> {
         decoration: BoxDecoration(
           color: isDark
               ? Colors.white.withValues(alpha: 0.08)
-              : AppColors.neutral100,
+              : Colors.white.withValues(alpha: 0.7),
           borderRadius: BorderRadius.circular(AppTheme.radiusSm),
         ),
         child: Icon(
@@ -353,7 +356,7 @@ class _TextsHistoryScreenState extends State<TextsHistoryScreen> {
               decoration: BoxDecoration(
                 color: isDark
                     ? Colors.white.withValues(alpha: 0.08)
-                    : AppColors.neutral100,
+                    : Colors.white.withValues(alpha: 0.7),
                 borderRadius: BorderRadius.circular(AppTheme.radiusXl),
               ),
               child: const Icon(

--- a/lib/features/history/presentation/screens/visiobooks_history_screen.dart
+++ b/lib/features/history/presentation/screens/visiobooks_history_screen.dart
@@ -286,10 +286,13 @@ class _VisiobooksHistoryScreenState extends State<VisiobooksHistoryScreen> {
           color: isSelected
               ? (isDark
                     ? Colors.white.withValues(alpha: 0.15)
-                    : AppColors.neutral900)
+                    : AppColors.neutral900.withValues(alpha: 0.08))
               : (isDark
                     ? Colors.white.withValues(alpha: 0.08)
                     : AppColors.neutral100),
+          border: isSelected && !isDark
+              ? Border.all(color: AppColors.neutral900.withValues(alpha: 0.15))
+              : null,
           borderRadius: BorderRadius.circular(AppTheme.radiusXl),
         ),
         child: Text(
@@ -298,7 +301,7 @@ class _VisiobooksHistoryScreenState extends State<VisiobooksHistoryScreen> {
             fontSize: 14,
             fontWeight: FontWeight.w500,
             color: isSelected
-                ? Colors.white
+                ? (isDark ? Colors.white : AppColors.neutral900)
                 : (isDark ? AppColors.neutral300 : AppColors.neutral600),
           ),
         ),
@@ -517,7 +520,7 @@ class _VisioBookCard extends StatelessWidget {
         return Container(
           color: isDark
               ? Colors.white.withValues(alpha: 0.08)
-              : AppColors.neutral100,
+              : Colors.white.withValues(alpha: 0.7),
           child: Center(
             child: Icon(
               LucideIcons.playCircle,

--- a/lib/features/import/presentation/screens/scanner_screen.dart
+++ b/lib/features/import/presentation/screens/scanner_screen.dart
@@ -322,7 +322,7 @@ class _ScannerScreenState extends State<ScannerScreen>
                   width: 80,
                   height: 80,
                   decoration: BoxDecoration(
-                    color: AppColors.neutral100,
+                    color: Colors.white.withValues(alpha: 0.7),
                     borderRadius: BorderRadius.circular(20),
                   ),
                   child: const Icon(
@@ -665,7 +665,7 @@ class _ScannerScreenState extends State<ScannerScreen>
                       width: 80,
                       height: 80,
                       decoration: BoxDecoration(
-                        color: AppColors.neutral100,
+                        color: Colors.white.withValues(alpha: 0.7),
                         borderRadius: BorderRadius.circular(20),
                       ),
                       child: const Icon(

--- a/lib/features/payment/presentation/screens/plans_screen.dart
+++ b/lib/features/payment/presentation/screens/plans_screen.dart
@@ -130,7 +130,7 @@ class _PlansScreenState extends State<PlansScreen> {
       decoration: BoxDecoration(
         color: isDark
             ? Colors.white.withValues(alpha: 0.08)
-            : AppColors.neutral100,
+            : Colors.white.withValues(alpha: 0.7),
         borderRadius: BorderRadius.circular(100),
         border: Border.all(
           color: isDark ? AppColors.neutral700 : AppColors.neutral200,
@@ -148,7 +148,7 @@ class _PlansScreenState extends State<PlansScreen> {
                   color: !_isYearly
                       ? (isDark
                             ? Colors.white.withValues(alpha: 0.15)
-                            : AppColors.neutral900)
+                            : AppColors.neutral900.withValues(alpha: 0.08))
                       : Colors.transparent,
                   borderRadius: BorderRadius.circular(100),
                 ),
@@ -159,7 +159,7 @@ class _PlansScreenState extends State<PlansScreen> {
                       fontSize: 14,
                       fontWeight: FontWeight.w600,
                       color: !_isYearly
-                          ? (isDark ? Colors.white : Colors.white)
+                          ? (isDark ? Colors.white : AppColors.neutral900)
                           : AppColors.neutral500,
                     ),
                   ),
@@ -177,7 +177,7 @@ class _PlansScreenState extends State<PlansScreen> {
                   color: _isYearly
                       ? (isDark
                             ? Colors.white.withValues(alpha: 0.15)
-                            : AppColors.neutral900)
+                            : AppColors.neutral900.withValues(alpha: 0.08))
                       : Colors.transparent,
                   borderRadius: BorderRadius.circular(100),
                 ),
@@ -188,7 +188,7 @@ class _PlansScreenState extends State<PlansScreen> {
                       fontSize: 14,
                       fontWeight: FontWeight.w600,
                       color: _isYearly
-                          ? (isDark ? Colors.white : Colors.white)
+                          ? (isDark ? Colors.white : AppColors.neutral900)
                           : AppColors.neutral500,
                     ),
                   ),
@@ -221,7 +221,7 @@ class _PlansScreenState extends State<PlansScreen> {
         color: isRecommended
             ? (isDark
                   ? Colors.white.withValues(alpha: 0.1)
-                  : AppColors.neutral900)
+                  : AppColors.neutral900.withValues(alpha: 0.06))
             : (isDark
                   ? Colors.white.withValues(alpha: 0.05)
                   : AppColors.neutral100),
@@ -229,7 +229,7 @@ class _PlansScreenState extends State<PlansScreen> {
           color: isRecommended
               ? (isDark
                     ? Colors.white.withValues(alpha: 0.25)
-                    : AppColors.neutral900)
+                    : AppColors.neutral900.withValues(alpha: 0.2))
               : (isDark ? AppColors.neutral700 : AppColors.neutral200),
           width: isRecommended ? 2 : 1,
         ),
@@ -249,9 +249,7 @@ class _PlansScreenState extends State<PlansScreen> {
                     Icon(
                       _planIcon(plan.id),
                       size: 20,
-                      color: isRecommended
-                          ? Colors.white
-                          : Theme.of(context).colorScheme.onSurface,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
                     const SizedBox(width: 8),
                     Text(
@@ -259,9 +257,7 @@ class _PlansScreenState extends State<PlansScreen> {
                       style: TextStyle(
                         fontSize: 18,
                         fontWeight: FontWeight.w600,
-                        color: isRecommended
-                            ? Colors.white
-                            : Theme.of(context).colorScheme.onSurface,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                     ),
                     const SizedBox(width: 8),
@@ -286,8 +282,9 @@ class _PlansScreenState extends State<PlansScreen> {
                           ),
                         ),
                       ),
-                    if (isCurrent && !isRecommended)
+                    if (isCurrent)
                       Container(
+                        margin: EdgeInsets.only(left: isRecommended ? 6 : 0),
                         padding: const EdgeInsets.symmetric(
                           horizontal: 8,
                           vertical: 3,
@@ -295,35 +292,22 @@ class _PlansScreenState extends State<PlansScreen> {
                         decoration: BoxDecoration(
                           color: isDark
                               ? Colors.white.withValues(alpha: 0.15)
-                              : AppColors.neutral900,
+                              : AppColors.neutral900.withValues(alpha: 0.08),
                           borderRadius: BorderRadius.circular(100),
+                          border: isDark
+                              ? null
+                              : Border.all(
+                                  color: AppColors.neutral900.withValues(
+                                    alpha: 0.12,
+                                  ),
+                                ),
                         ),
-                        child: const Text(
+                        child: Text(
                           'Plan actuel',
                           style: TextStyle(
                             fontSize: 11,
                             fontWeight: FontWeight.w600,
-                            color: Colors.white,
-                          ),
-                        ),
-                      ),
-                    if (isCurrent && isRecommended)
-                      Container(
-                        margin: const EdgeInsets.only(left: 6),
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 8,
-                          vertical: 3,
-                        ),
-                        decoration: BoxDecoration(
-                          color: Colors.white.withValues(alpha: 0.2),
-                          borderRadius: BorderRadius.circular(100),
-                        ),
-                        child: const Text(
-                          'Plan actuel',
-                          style: TextStyle(
-                            fontSize: 11,
-                            fontWeight: FontWeight.w600,
-                            color: Colors.white,
+                            color: isDark ? Colors.white : AppColors.neutral900,
                           ),
                         ),
                       ),
@@ -334,11 +318,7 @@ class _PlansScreenState extends State<PlansScreen> {
                   plan.description,
                   style: TextStyle(
                     fontSize: 13,
-                    color: isRecommended
-                        ? Colors.white.withValues(alpha: 0.7)
-                        : (isDark
-                              ? AppColors.neutral400
-                              : AppColors.neutral500),
+                    color: isDark ? AppColors.neutral400 : AppColors.neutral500,
                   ),
                 ),
                 const SizedBox(height: 12),
@@ -350,9 +330,7 @@ class _PlansScreenState extends State<PlansScreen> {
                       style: TextStyle(
                         fontSize: 24,
                         fontWeight: FontWeight.bold,
-                        color: isRecommended
-                            ? Colors.white
-                            : Theme.of(context).colorScheme.onSurface,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                     ),
                     if (_isYearly && savings > 0) ...[
@@ -395,9 +373,7 @@ class _PlansScreenState extends State<PlansScreen> {
                           Icon(
                             LucideIcons.check,
                             size: 16,
-                            color: isRecommended
-                                ? Colors.white
-                                : Theme.of(context).colorScheme.onSurface,
+                            color: Theme.of(context).colorScheme.onSurface,
                           ),
                           const SizedBox(width: 10),
                           Expanded(
@@ -405,11 +381,9 @@ class _PlansScreenState extends State<PlansScreen> {
                               feature,
                               style: TextStyle(
                                 fontSize: 14,
-                                color: isRecommended
-                                    ? Colors.white.withValues(alpha: 0.9)
-                                    : (isDark
-                                          ? AppColors.neutral300
-                                          : AppColors.neutral700),
+                                color: isDark
+                                    ? AppColors.neutral300
+                                    : AppColors.neutral700,
                               ),
                             ),
                           ),

--- a/lib/features/payment/presentation/screens/subscription_screen.dart
+++ b/lib/features/payment/presentation/screens/subscription_screen.dart
@@ -615,7 +615,7 @@ class _SubscriptionScreenState extends State<SubscriptionScreen> {
       decoration: BoxDecoration(
         color: isDark
             ? Colors.white.withValues(alpha: 0.05)
-            : AppColors.neutral100,
+            : Colors.white.withValues(alpha: 0.7),
         border: Border.all(
           color: isDark ? AppColors.neutral700 : AppColors.neutral200,
         ),

--- a/lib/features/player/presentation/widgets/generation_selector_sheet.dart
+++ b/lib/features/player/presentation/widgets/generation_selector_sheet.dart
@@ -163,7 +163,7 @@ class _GenerationTile extends StatelessWidget {
               width: 80,
               height: 60,
               decoration: BoxDecoration(
-                color: AppColors.neutral100,
+                color: Colors.white.withValues(alpha: 0.7),
                 borderRadius: BorderRadius.circular(8),
                 border: Border.all(color: AppColors.neutral200),
               ),

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -189,8 +189,13 @@ class _ProfileScreenState extends State<ProfileScreen> {
             decoration: BoxDecoration(
               color: Theme.of(context).brightness == Brightness.dark
                   ? Colors.white.withValues(alpha: 0.15)
-                  : AppColors.neutral900,
+                  : AppColors.neutral900.withValues(alpha: 0.08),
               shape: BoxShape.circle,
+              border: Theme.of(context).brightness == Brightness.light
+                  ? Border.all(
+                      color: AppColors.neutral900.withValues(alpha: 0.12),
+                    )
+                  : null,
             ),
             child: Center(
               child: Text(
@@ -198,7 +203,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                 style: TextStyle(
                   color: Theme.of(context).brightness == Brightness.dark
                       ? Colors.white
-                      : Colors.white,
+                      : AppColors.neutral900,
                   fontSize: 24,
                   fontWeight: FontWeight.w600,
                 ),
@@ -280,13 +285,18 @@ class _ProfileScreenState extends State<ProfileScreen> {
                   decoration: BoxDecoration(
                     color: isDark
                         ? Colors.white.withValues(alpha: 0.15)
-                        : AppColors.neutral900,
+                        : AppColors.neutral900.withValues(alpha: 0.08),
                     borderRadius: BorderRadius.circular(12),
+                    border: isDark
+                        ? null
+                        : Border.all(
+                            color: AppColors.neutral900.withValues(alpha: 0.12),
+                          ),
                   ),
                   child: Text(
                     planName,
-                    style: const TextStyle(
-                      color: Colors.white,
+                    style: TextStyle(
+                      color: isDark ? Colors.white : AppColors.neutral900,
                       fontSize: 12,
                       fontWeight: FontWeight.w600,
                     ),
@@ -903,7 +913,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                 ? AppColors.info.withValues(alpha: 0.15)
                 : isDark
                 ? Colors.white.withValues(alpha: 0.05)
-                : AppColors.neutral100,
+                : Colors.white.withValues(alpha: 0.7),
             borderRadius: BorderRadius.circular(8),
             border: Border.all(
               color: selected ? AppColors.info : Colors.transparent,
@@ -1011,9 +1021,11 @@ class _ProfileScreenState extends State<ProfileScreen> {
       decoration: BoxDecoration(
         color: isDark
             ? Colors.white.withValues(alpha: 0.05)
-            : AppColors.neutral100,
+            : Colors.white.withValues(alpha: 0.7),
         border: Border.all(
-          color: isDark ? AppColors.neutral700 : AppColors.neutral200,
+          color: isDark
+              ? AppColors.neutral700
+              : Colors.black.withValues(alpha: 0.08),
         ),
         borderRadius: BorderRadius.circular(AppTheme.radiusMd),
       ),

--- a/lib/features/project_detail/presentation/screens/project_view_screen.dart
+++ b/lib/features/project_detail/presentation/screens/project_view_screen.dart
@@ -174,7 +174,7 @@ class _ProjectViewScreenState extends State<ProjectViewScreen> {
       decoration: BoxDecoration(
         color: isDark
             ? Colors.white.withValues(alpha: 0.05)
-            : AppColors.neutral100,
+            : Colors.white.withValues(alpha: 0.7),
         borderRadius: BorderRadius.circular(AppTheme.radiusLg),
         border: Border.all(
           color: isDark ? AppColors.neutral700 : AppColors.neutral200,
@@ -320,7 +320,7 @@ class _ProjectViewScreenState extends State<ProjectViewScreen> {
       decoration: BoxDecoration(
         color: isDark
             ? Colors.white.withValues(alpha: 0.05)
-            : AppColors.neutral100,
+            : Colors.white.withValues(alpha: 0.7),
         borderRadius: BorderRadius.circular(AppTheme.radiusMd),
         border: Border.all(
           color: isDark ? AppColors.neutral700 : AppColors.neutral200,
@@ -370,7 +370,7 @@ class _ActionButton extends StatelessWidget {
         decoration: BoxDecoration(
           color: isDark
               ? Colors.white.withValues(alpha: 0.05)
-              : AppColors.neutral100,
+              : Colors.white.withValues(alpha: 0.7),
           borderRadius: BorderRadius.circular(AppTheme.radiusMd),
           border: Border.all(
             color: isDark ? AppColors.neutral700 : AppColors.neutral200,

--- a/lib/features/project_detail/presentation/widgets/option_selector.dart
+++ b/lib/features/project_detail/presentation/widgets/option_selector.dart
@@ -50,7 +50,7 @@ class OptionSelector<T> extends StatelessWidget {
               decoration: BoxDecoration(
                 color: isDark
                     ? Colors.white.withValues(alpha: 0.08)
-                    : AppColors.neutral100,
+                    : Colors.white.withValues(alpha: 0.7),
                 borderRadius: BorderRadius.circular(12),
               ),
               child: Icon(

--- a/lib/features/project_detail/presentation/widgets/style_selector.dart
+++ b/lib/features/project_detail/presentation/widgets/style_selector.dart
@@ -90,7 +90,7 @@ class _StyleCard extends StatelessWidget {
                 width: double.infinity,
                 color: isDark
                     ? Colors.white.withValues(alpha: 0.08)
-                    : AppColors.neutral100,
+                    : Colors.white.withValues(alpha: 0.7),
                 child: Image.network(
                   style.previewUrl,
                   fit: BoxFit.cover,


### PR DESCRIPTION
…s, badges)

- Replace opaque white backgrounds with 70% opacity glass white
- Update theme: surface, cards, inputs use semi-transparent fills
- Replace neutral100 backgrounds globally across all feature screens
- Profile cards, history filters, plan cards, inputs all now glass-style
- Light mode now matches dark mode glassmorphism aesthetic

Closes #72